### PR TITLE
Supporting config.ini per buildtype as an option.

### DIFF
--- a/common/ConfigFile.py
+++ b/common/ConfigFile.py
@@ -5,6 +5,17 @@ import string
 import ConfigParser
 
 
+# This task is a wrapper for read_config_file() to
+# optionally allow a config file per buildtype
+@task
+def buildtype_config_file(buildtype, config_filename='config.ini', abort_if_missing=True, fullpath=False, remote=False):
+  cwd = os.getcwd()
+  buildtype_config_filename = buildtype + '.' + config_filename
+  if os.path.isfile(cwd + '/' + buildtype_config_filename):
+    config_filename = buildtype_config_filename
+  return read_config_file(config_filename, abort_if_missing, fullpath, remote)
+
+
 @task
 def read_config_file(config_filename='config.ini', abort_if_missing=True, fullpath=False, remote=False):
   # Fetch the host to deploy to, from the mapfile, according to its repo and build type

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -25,13 +25,14 @@ from FeatureBranches import *
 # pesky 'stdin is not a tty' messages when using sudo
 env.shell = '/bin/bash -c'
 
-# Read the config.ini file from repo, if it exists
 global config
-config = common.ConfigFile.read_config_file()
 
 
 @task
-def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", keepbuilds=10, runcron="False", doupdates="Yes", freshdatabase="Yes", syncbranch=None, sanitise="no", statuscakeuser=None, statuscakekey=None, statuscakeid=None, importconfig="yes", restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', rds=False):
+def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", keepbuilds=10, runcron="False", doupdates="Yes", freshdatabase="Yes", syncbranch=None, sanitise="no", statuscakeuser=None, statuscakekey=None, statuscakeid=None, importconfig="yes", restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', rds=False, config_filename='config.ini'):
+
+  # Read the config.ini file from repo, if it exists
+  config = common.ConfigFile.buildtype_config_file(buildtype, config_filename)
 
   # Define variables
   drupal_version = None


### PR DESCRIPTION
Adding a wrapper function to leave the standard config.ini in place but provide a route to support buildtype-specific config.ini files in the main fabfiles if we need to.