### PR TITLE
Allowing us to bypass 'composer install'

### DIFF
--- a/drupal/fabfile-multisite.py
+++ b/drupal/fabfile-multisite.py
@@ -31,7 +31,7 @@ config = common.ConfigFile.read_config_file()
 # New 'main()' task which should replace the deployment.sh wrapper, and support repo -> host mapping
 #####
 @task
-def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", keepbuilds=10, runcron="False", doupdates="Yes", freshdatabase="Yes", syncbranch=None, sanitise="no", statuscakeuser=None, statuscakekey=None, statuscakeid=None, importconfig="yes", restartvarnish="yes", cluster=False, webserverport='8080', rds=False):
+def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", keepbuilds=10, runcron="False", doupdates="Yes", freshdatabase="Yes", syncbranch=None, sanitise="no", statuscakeuser=None, statuscakekey=None, statuscakeid=None, importconfig="yes", restartvarnish="yes", cluster=False, webserverport='8080', rds=False, composer=True):
   dontbuild = False
 
   # Define variables

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -29,7 +29,7 @@ global config
 
 
 @task
-def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", keepbuilds=10, runcron="False", doupdates="Yes", freshdatabase="Yes", syncbranch=None, sanitise="no", statuscakeuser=None, statuscakekey=None, statuscakeid=None, importconfig="yes", restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', rds=False, config_filename='config.ini'):
+def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", keepbuilds=10, runcron="False", doupdates="Yes", freshdatabase="Yes", syncbranch=None, sanitise="no", statuscakeuser=None, statuscakekey=None, statuscakeid=None, importconfig="yes", restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', rds=False, composer=True, config_filename='config.ini'):
 
   # Read the config.ini file from repo, if it exists
   config = common.ConfigFile.buildtype_config_file(buildtype, config_filename)
@@ -137,7 +137,7 @@ def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", k
 
     if drupal_version != '8':
       importconfig = "no"
-    if drupal_version == '8':
+    if drupal_version == '8' and composer is True:
       execute(Drupal.run_composer_install, repo, branch, build)
     if freshdatabase == "Yes" and buildtype == "custombranch":
       # For now custombranch builds to clusters cannot work
@@ -212,7 +212,7 @@ def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", k
     execute(AdjustConfiguration.adjust_drushrc_php, repo, branch, build)
     execute(Drupal.environment_indicator, repo, branch, build, buildtype, drupal_version)
     execute(AdjustConfiguration.adjust_files_symlink, repo, branch, build)
-    if drupal_version == '8':
+    if drupal_version == '8' and composer is True:
       execute(Drupal.run_composer_install, repo, branch, build)
 
     # Let's allow developers to perform some actions right after Drupal is built

--- a/util/fabfile.py
+++ b/util/fabfile.py
@@ -39,4 +39,4 @@ def main(jenkins_server=None, scripts_path="/var/lib/jenkins/scripts", branch="m
   else:
     common.Utils._sshagent_run("cd %s; git pull origin %s" % (scripts_path, branch), ssh_key)
 
-  print ("####### BUILD COMPLETE. Branch %s was refreshed on server %s at path %s" % (branch, scripts_path, env.host))
+  print ("####### SCRIPTS UPDATED. Branch %s was refreshed on server %s at path %s" % (branch, scripts_path, env.host))


### PR DESCRIPTION
Simple solution, I prefer this to detecting "vendor" in the repo, I don't think we should assume if "vendor" is present the developer doesn't want a `composer install` - ultimately we'll want this in config.ini, but a manual Jenkins flag for now is fine, I think.