### PR TITLE
Allow wildcard for features and check that features module is installed

### DIFF
--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -300,7 +300,7 @@ def drush_fra(repo, branch, build, drupal_version):
     else:
       print "===> Reverting all features..."
       with settings(warn_only=True):
-        if sudo("su -s /bin/bash www-data -c 'cd /var/www/%s_%s_%s/www/sites/default && drush -y fra'" % (repo, branch, build)).failed:
+        if sudo("su -s /bin/bash www-data -c 'drush -y fra'" % (repo, branch, build)).failed:
           print "Could not revert features! Reverting database and settings..."
           Revert._revert_db(repo, branch, build)
           Revert._revert_settings(repo, branch, build)

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -86,7 +86,7 @@ def main(repo, repourl, build, branch, buildtype, url=None, profile="minimal", k
   if config.has_section("Features"):
     fra = config.getboolean("Features", "fra")
     if fra == True:
-      branches = Drupal.drush_fra_branches(config)
+      branches = Drupal.drush_fra_branches(config, branch)
   readonlymode = Drupal.configure_readonlymode(config)
 
   # These are our standard deployment hooks, such as config_export


### PR DESCRIPTION
This is a suggested change to allow a wildcard to be used for the [Features] configuration option rather then having to explicitly name branches.

Also, added a check to make sure the the features module is actually installed before attempting a feature revert.

