### PR TITLE
In order for s3 uploads to work with the db backup utility some paths…

### DIFF
--- a/drupal/fabfile-databasedump.py
+++ b/drupal/fabfile-databasedump.py
@@ -16,7 +16,7 @@ def main(shortname, branch, bucket_name, method='zip', sanitise='yes'):
 
   try:
     DrupalUtils.get_database(shortname, branch, sanitise)
-    common.Utils.s3_upload(shortname, branch, method, shortname, bucket_name)
+    common.Utils.s3_upload(shortname, branch, method, "database_dump", bucket_name, "client-db-dumps")
   except:
     e = sys.exc_info()[1]
     raise SystemError(e)


### PR DESCRIPTION
… need tweaking when it is called.

Currently it's looking for /tmp/s3-uploads/bcc_d7-master_bcc_d7.sql.bz2

The file is actually at /tmp/client-db-dumps/bcc_d7-master_database_dump.sql.bz2

I believe this change will correct the location of the db backup on the Jenkins server.