### PR TITLE
We don't need any of those changes, because the AWS credentials will …

### DIFF
--- a/common/ConfigFile.py
+++ b/common/ConfigFile.py
@@ -18,7 +18,7 @@ def buildtype_config_file(buildtype, config_filename='config.ini', abort_if_miss
 
 
 @task
-def read_config_file(config_filename='config.ini', abort_if_missing=True, fullpath=False, remote=False, autoscale=None):
+def read_config_file(config_filename='config.ini', abort_if_missing=True, fullpath=False, remote=False):
   # Fetch the host to deploy to, from the mapfile, according to its repo and build type
   config_file = ConfigParser.RawConfigParser()
   # Force case-sensitivity
@@ -45,14 +45,9 @@ def read_config_file(config_filename='config.ini', abort_if_missing=True, fullpa
     print "===> Trying to read REMOTE file %s if it is present" % path_to_config_file
     if run("find %s -type f" % path_to_config_file).return_code == 0:
       config_file_contents = run("cat %s" % path_to_config_file)
-      if autoscale is None:
-        local_config_path = cwd + '/config.ini'
-      else:
-        local_config_path = cwd + '/autoscale-config.ini'
+      local_config_path = cwd + '/config.ini'
       local("echo '%s' > %s" % (config_file_contents, local_config_path))
       config_file.read(local_config_path)
-      if autoscale:
-        local("rm %s" % local_config_path)
       return config_file
     # Otherwise, abort the build / report missing file.
     else:

--- a/common/Utils.py
+++ b/common/Utils.py
@@ -231,7 +231,7 @@ def define_roles(config, cluster, autoscale=None, aws_credentials='/home/jenkins
 
   elif autoscale:
     # Load in AWS credentials from autoscale variable
-    aws_config = common.ConfigFile.read_config_file(aws_credentials, abort_if_missing=True, fullpath=True, remote=True, autoscale=autoscale)
+    aws_config = common.ConfigFile.read_config_file(aws_credentials, abort_if_missing=True, fullpath=True)
     # Blank the apps array, just in case
     all_apps = []
     # Make sure we have AWS credentials


### PR DESCRIPTION
…always been on the Jenkins server (or at least they should be for now). So putting things back to what they were before.