### PR TITLE
Moving when we delete db dump

### DIFF
--- a/drupal/Sync.py
+++ b/drupal/Sync.py
@@ -167,11 +167,15 @@ def sync_db(orig_host, shortname, staging_branch, prod_branch, fresh_database, s
 
   print "===> Sending database dumps to destination server"
   local('scp /tmp/dbbackups/drupal_%s_%s_from_prod.sql.bz2 %s:~/dbbackups/' % (shortname, now, env.host_string))
-  local('rm /tmp/dbbackups/drupal_%s_%s_from_prod.sql.bz2' % (shortname, now))
 
   print "===> Check the production database has actually been copied down"
   if run("stat /home/jenkins/dbbackups/drupal_%s_%s_from_prod.sql.bz2" % (shortname, now)).failed:
+    # Clean up local copy
+    local('rm /tmp/dbbackups/drupal_%s_%s_from_prod.sql.bz2' % (shortname, now))
     raise SystemExit("Nope, production database hasn't been copied down. Abort now, as the stage site will go down if we proceed.")
+
+  # Now we've verified success we can clean up the local DB archive
+  local('rm /tmp/dbbackups/drupal_%s_%s_from_prod.sql.bz2' % (shortname, now))
 
   print "===> Importing the drupal database"
   # Need to drop all tables first in case there are existing tables that have to be ADDED from an upgrade


### PR DESCRIPTION
I know this was tidier as a one-liner, however it's handy to know how far Jenkins got by virtue of whether or not the db dump is still there on the Jenkins server - so this helps debug a little.