### PR TITLE
drush_fra_branches: need to declare branches before appending to it

### DIFF
--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -12,6 +12,7 @@ import Revert
 def drush_fra_branches(config, branch):
   # If a 'branches' option exists in the [Features] section in config.ini, proceed
   if config.has_option("Features", "branches"):
+    branches = []
     # Get the 'branches' option from under the [Features] section
     revert_features = config.get("Features", "branches")
     if revert_features == "*":


### PR DESCRIPTION
I feel like I must be missing something here and I'm ready to be shot down, but as far as I can tell the drush_fra_branches code will always fail with `NameError: name 'branches' is not defined` because python won't allow a list to be appended to if it doesn't already exist.
