### PR TITLE
fix typeerror for D7

### DIFF
--- a/drupal/AdjustConfiguration.py
+++ b/drupal/AdjustConfiguration.py
@@ -16,7 +16,7 @@ def adjust_settings_php(repo, branch, build, buildtype, alias, site):
       # No "config" directory
       sudo("mkdir --mode 0755 /var/www/config")
       sudo("chown jenkins:www-data /var/www/config")
-      
+
   # In some cases it seems jenkins loses write permissions to the site directory
   # Let's make sure!
   sudo("chmod -R 775 /var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site))
@@ -37,7 +37,7 @@ def adjust_settings_php(repo, branch, build, buildtype, alias, site):
     # 1. First check if the settings.inc file exists in 'config'
     if run("stat /var/www/config/%s_%s.settings.inc" % (alias, branch)).failed:
       # 2. We didn't find the shared file. Check if settings.php exists for this site.
-      print "The shared settings file /var/www/config/%s_%s.settings.inc was not found. We'll try and move a sites/%s/settings.php file there, if it exists." % (alias, branch, repo, branch, site)
+      print "The shared settings file /var/www/config/%s_%s.settings.inc was not found. We'll try and move a sites/%s/settings.php file there, if it exists." % (alias, branch, repo)
       if run("stat /var/www/%s_%s_%s/www/sites/%s/settings.php" % (repo, branch, build, site)).failed:
         # 3. Doesn't look like settings.php exists for this site. We'll see if a $branch.settings.php file exists instead, as a last resort.
         print "We couldn't find /var/www/%s_%s_%s/www/sites/%s/settings.php, so we'll search for a buildtype specific file as a last resort." % (repo, branch, build, site)
@@ -128,4 +128,3 @@ def adjust_drushrc_php(repo, branch, build, site):
         print "Could not copy /var/www/%s_%s_%s/www/sites/%s/%s.drushrc.php to /var/www/%s_%s_%s/www/sites/%s/drushrc.php. Continuing with build, but perhaps have a look into why the file couldn't be copied." % (repo, branch, build, site, branch, repo, branch, build, site)
       else:
         print "Copied /var/www/%s_%s_%s/www/sites/%s/%s.drushrc.php to /var/www/%s_%s_%s/www/sites/%s/drushrc.php" % (repo, branch, build, site, branch, repo, branch, build, site)
-


### PR DESCRIPTION
Fix is pretty self-explanatory, there were a couple of rogue parameters in there. This was enough to break a D7 build.
