### PR TITLE
More featurebranch url fixes

### DIFF
--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -50,7 +50,9 @@ def configure_feature_branch(buildtype, config, branch, alias):
   global ssl_ip
   global ssl_cert
   global drupal_common_config
-  global url
+  global featurebranch_url
+
+  featurebranch_url = None
 
 
   # If the buildtype is 'custombranch', which it will be when deploying a custom branch (i.e one
@@ -116,7 +118,7 @@ def configure_feature_branch(buildtype, config, branch, alias):
             urltemplate = urltemplate.replace("reponame", alias, 1)
             urltemplate = urltemplate.replace("branchname", branch, 1)
             print "urltemplate is now %s" % urltemplate
-            url = urltemplate
+            featurebranch_url = urltemplate
 
           if config.has_option("featurebranch", "drupalcommonconfig"):
             print "Feature Branch: Found a drupalcommonconfig option..."

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -157,11 +157,15 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
     print "ssl_cert: %s" % FeatureBranches.ssl_cert
     print "ssl_ip: %s" % FeatureBranches.ssl_ip
     print "drupal_common_config: %s" % FeatureBranches.drupal_common_config
-    print "url: %s" % FeatureBranches.url
+    print "featurebranch_url: %s" % FeatureBranches.featurebranch_url
 
     if freshdatabase == "Yes" and buildtype == "custombranch":
       # For now custombranch builds to clusters cannot work
       dump_file = Drupal.prepare_database(repo, branch, build, alias, syncbranch, env.host_string, sanitise, drupal_version, sanitised_password, sanitised_email)
+
+    if FeatureBranches.featurebranch_url is not None:
+      url = FeatureBranches.featurebranch_url
+
     url = common.Utils.generate_url(url, alias, branch)
     # Now check if we have a Drush alias with that name. If not, run an install
     with settings(hide('warnings', 'stderr'), warn_only=True):


### PR DESCRIPTION
Again for #127. I've reworked the variable that's used, as for some reason the global `url` variable couldn't be used. 