### PR TITLE
fix for drush 9 database name parsing

### DIFF
--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -134,7 +134,7 @@ def remove_site(repo, branch, alias):
   # Drop DB...
   with cd("/var/www/live.%s.%s/www/sites/default" % (repo, branch)):
     with settings(warn_only=True):
-      dbname = sudo("drush status 2>&1 | grep \"Database name \" | cut -d \":\" -f 2")
+      dbname = sudo("drush status 2>&1 | grep \"Database name \|DB name \" | cut -d \":\" -f 2")
       print "DEBUG INFO: dbname = %s" % dbname
 
       # If the dbname variable is empty for whatever reason, resort to grepping settings.php


### PR DESCRIPTION
A quick partial fix for https://github.com/codeenigma/deployments/issues/99 as some of our Teardowns started failing.

e.g.
```
run: drush sa | grep '^@\?REDACTED$' > /dev/null
sudo: drush status 2>&1 | grep "Database name " | cut -d ":" -f 2
DEBUG INFO: dbname = 
sudo: grep "'database' => 'REDACTED*" settings.php | cut -d ">" -f 2
sudo: mysql --defaults-file=/etc/mysql/debian.cnf -e 'DROP DATABASE IF EXISTS ``;'
out: ERROR 1102 (42000) at line 1: Incorrect database name ''
```