### PR TITLE
remove_old_builds: follow symlink when searching for builds

### DIFF
--- a/util/remove_old_builds.sh
+++ b/util/remove_old_builds.sh
@@ -52,7 +52,7 @@ fi
 
 # The magic to remove the old builds
 PATTERN=$REPO'_'$BRANCH'_build_*'
-REMAINING=`find $WWWDIR -maxdepth 1 -type d -name "$PATTERN" | wc -l`
+REMAINING=`find -L $WWWDIR -maxdepth 1 -type d -name "$PATTERN" | wc -l`
 if [ $REMAINING -eq 0 ]; then
   echo "Didn't find any builds. Exiting"
   exit


### PR DESCRIPTION
Tiny fix related to https://github.com/codeenigma/deployments/issues/22

Add a switch to the find command that looks for old builds to remove, the switch lets the find command follow symlinks. This solves the problem where `/var/www` is a symlink to somewhere else, whilst not causing problems where `/var/www` is an absolute path.

