### PR TITLE
CodeSniffer support

### DIFF
--- a/common/ConfigFile.py
+++ b/common/ConfigFile.py
@@ -76,6 +76,10 @@ def return_config_item(config, section, item, var_type="string", default_value=N
       if notify:
         print "===> %s in [%s] being set to %s" % (item, section, config.getboolean(section, item))
       default_value = config.getboolean(section, item)
+    elif var_type is "int":
+      if notify:
+        print "===> %s in [%s] being set to %s" % (item, section, config.getint(section, item))
+      default_value = config.getint(section, item)
     else:
       if notify:
         print "===> tried to look up %s %s in [%s] but type not found" % (var_type, item, section)

--- a/common/Tests.py
+++ b/common/Tests.py
@@ -9,7 +9,7 @@ import time
 # Run phpunit tests
 @task
 @roles('app_primary')
-def run_phpunit_tests(repo, branch, build, group='unit', path='www', phpunit_path='vendor/phpunit/phpunit/phpunit'):
+def run_phpunit_tests(path_to_app, group='unit', path='www', phpunit_path='vendor/phpunit/phpunit/phpunit'):
   phpunit_tests_failed=True
   # We cannot make phpunit work with PHP 5.x, too many problems
   # Detect PHP version
@@ -18,7 +18,7 @@ def run_phpunit_tests(repo, branch, build, group='unit', path='www', phpunit_pat
     # Sorry, PHP too old!
     print "##### Sorry, this version of PHP is too old for current phpunit builds, we cannot run the tests."
     return phpunit_tests_failed
-  with cd("/var/www/%s_%s_%s" % (repo, branch, build)):
+  with cd("%s" % path_to_app):
     # Make sure phpunit is available to use
     # We don't want to fail if it's already there
     with settings(warn_only=True):
@@ -28,21 +28,21 @@ def run_phpunit_tests(repo, branch, build, group='unit', path='www', phpunit_pat
     phpunit_xml = False
     with settings(warn_only=True):
       # Usual place to expect phpunit.xml
-      if run("find /var/www/%s_%s_%s/phpunit.xml" % (repo, branch, build)).return_code == 0:
+      if run("find %s/phpunit.xml" % path_to_app).return_code == 0:
         phpunit_xml = "phpunit.xml"
       # For Drupal it might be here
-      elif run("find /var/www/%s_%s_%s/www/core/phpunit.xml" % (repo, branch, build)).return_code == 0:
+      elif run("find %s/www/core/phpunit.xml" % path_to_app).return_code == 0:
         phpunit_xml = "www/core/phpunit.xml"
       # Doesn't look like there is one, let's look for phpunit's default file
-      elif run("find /var/www/%s_%s_%s/phpunit.xml.dist" % (repo, branch, build)).return_code == 0:
+      elif run("find %s/phpunit.xml.dist" % path_to_app).return_code == 0:
         phpunit_xml = "phpunit.xml.dist"
       # Nope, last chance, is there a default one in Drupal?
-      elif run("find /var/www/%s_%s_%s/www/core/phpunit.xml.dist" % (repo, branch, build)).return_code == 0:
+      elif run("find %s/www/core/phpunit.xml.dist" % path_to_app).return_code == 0:
         phpunit_xml = "www/core/phpunit.xml.dist"
 
     # Not let's run tests
     if phpunit_xml:
-      with cd("/var/www/%s_%s_%s" % (repo, branch, build)):
+      with cd("%s" % path_to_app):
         with settings(warn_only=True):
           if group == '' and path == '':
             if run('%s --configuration=%s' % (phpunit_path, phpunit_xml)).failed:
@@ -60,3 +60,28 @@ def run_phpunit_tests(repo, branch, build, group='unit', path='www', phpunit_pat
       print "===> PHPUNIT FAILED! No phpunit.xml was found so we could not run tests"
       
     return phpunit_tests_failed
+
+
+# Run CodeSniffer reviews
+@task
+@roles('app_primary')
+def run_codesniffer(path_to_app, extensions="php,inc,txt,md", standard=None, ignore=None, paths_to_test=None, config_path=None):
+  print "===> Running CodeSniffer"
+  # Install CodeSniffer for the Jenkins user
+  run("composer global require squizlabs/php_codesniffer")
+  # Load in custom config, if provided
+  if config_path:
+    run("/home/jenkins/.composer/vendor/bin/phpcs --config-set installed_paths %s" % config_path)
+  # Set up string of directories to ignore
+  if ignore:
+    ignore = " --ignore=%s" % ignore
+  else:
+    ignore = ""
+  # Set up 'standard' to use, if provided
+  if standard:
+    standard = " --standard=%s" % standard
+  else:
+    standard = ""
+  # Run CodeSniffer itself
+  with cd("%s" % path_to_app):
+    run("/home/jenkins/.composer/vendor/bin/phpcs %s --extensions=%s %s %s" % (standard, extensions, ignore, paths_to_test))

--- a/common/Tests.py
+++ b/common/Tests.py
@@ -65,10 +65,11 @@ def run_phpunit_tests(path_to_app, group='unit', path='www', phpunit_path='vendo
 # Run CodeSniffer reviews
 @task
 @roles('app_primary')
-def run_codesniffer(path_to_app, extensions="php,inc,txt,md", standard=None, ignore=None, paths_to_test=None, config_path=None):
+def run_codesniffer(path_to_app, extensions="php,inc,txt,md", install=True, standard=None, ignore=None, paths_to_test=None, config_path=None):
   print "===> Running CodeSniffer"
   # Install CodeSniffer for the Jenkins user
-  run("composer global require squizlabs/php_codesniffer")
+  if install:
+    run("composer global require squizlabs/php_codesniffer")
   # Load in custom config, if provided
   if config_path:
     run("/home/jenkins/.composer/vendor/bin/phpcs --config-set installed_paths %s" % config_path)

--- a/drupal/DrupalTests.py
+++ b/drupal/DrupalTests.py
@@ -1,8 +1,6 @@
 from fabric.api import *
 from fabric.contrib.files import sed
 import os
-# Custom Code Enigma modules
-import common.ConfigFile
 
 
 # Builds the variables needed to carry out Behat testing later

--- a/drupal/DrupalTests.py
+++ b/drupal/DrupalTests.py
@@ -1,6 +1,8 @@
 from fabric.api import *
 from fabric.contrib.files import sed
 import os
+# Custom Code Enigma modules
+import common.Tests
 
 
 # Builds the variables needed to carry out Behat testing later
@@ -64,14 +66,12 @@ def run_tests(repo, branch, build, config, drupal_version, codesniffer=False, ex
   if drupal_version > 7 and codesniffer:
     print "===> Drupal 8 or higher, running CodeSniffer"
     with settings(warn_only=True):
-      # Install CodeSniffer
+      # Install Drupal CodeSniffer standards
       run("composer global require drupal/coder")
-      # Configure CodeSniffer for Drupal
-      run("/home/jenkins/.composer/vendor/bin/phpcs --config-set installed_paths /home/jenkins/.composer/vendor/drupal/coder/coder_sniffer")
-      # Run the actual tests
-      with cd("%s/%s_%s_%s" % (www_root, repo, branch, build)):
-        run("/home/jenkins/.composer/vendor/bin/phpcs --standard=Drupal --extensions=%s --ignore=%s %s" % (extensions, ignore, paths_to_test))
-        run("/home/jenkins/.composer/vendor/bin/phpcs --standard=DrupalPractice --extensions=%s --ignore=%s %s" % (extensions, ignore, paths_to_test))
+      # Run CodeSniffer
+      path_to_app = "%s/%s_%s_%s" % (www_root, repo, branch, build)
+      common.Tests.run_codesniffer(path_to_app, extensions, standard="Drupal", ignore, paths_to_test, config_path="/home/jenkins/.composer/vendor/drupal/coder/coder_sniffer")
+      common.Tests.run_codesniffer(path_to_app, extensions, standard="DrupalPractice", ignore, paths_to_test, config_path="/home/jenkins/.composer/vendor/drupal/coder/coder_sniffer")
 
   # Obsolete really, but no harm in leaving Simpletest / Coder support for Drupal 7 for now
   else:

--- a/drupal/DrupalTests.py
+++ b/drupal/DrupalTests.py
@@ -68,10 +68,10 @@ def run_tests(repo, branch, build, config, drupal_version, codesniffer=False, ex
     with settings(warn_only=True):
       # Install Drupal CodeSniffer standards
       run("composer global require drupal/coder")
-      # Run CodeSniffer
       path_to_app = "%s/%s_%s_%s" % (www_root, repo, branch, build)
-      common.Tests.run_codesniffer(path_to_app, extensions, standard="Drupal", ignore, paths_to_test, config_path="/home/jenkins/.composer/vendor/drupal/coder/coder_sniffer")
-      common.Tests.run_codesniffer(path_to_app, extensions, standard="DrupalPractice", ignore, paths_to_test, config_path="/home/jenkins/.composer/vendor/drupal/coder/coder_sniffer")
+      # Run CodeSniffer, note install=False, suppresses trying to reinstall CodeSniffer, which will fail
+      common.Tests.run_codesniffer(path_to_app, extensions, install=False, standard="Drupal", ignore, paths_to_test, config_path="/home/jenkins/.composer/vendor/drupal/coder/coder_sniffer")
+      common.Tests.run_codesniffer(path_to_app, extensions, install=False, standard="DrupalPractice", ignore, paths_to_test, config_path="/home/jenkins/.composer/vendor/drupal/coder/coder_sniffer")
 
   # Obsolete really, but no harm in leaving Simpletest / Coder support for Drupal 7 for now
   else:

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -97,11 +97,17 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   no_dev = common.ConfigFile.return_config_item(config, "Composer", "no_dev", "boolean", True)
 
   # Can be set in the config.ini [Testing] section
+  # PHPUnit is in 'common' because it can be used for any PHP application
   phpunit_run = common.ConfigFile.return_config_item(config, "Testing", "phpunit_run", "boolean", False)
   phpunit_fail_build = common.ConfigFile.return_config_item(config, "Testing", "phpunit_fail_build", "boolean", False)
   phpunit_group = common.ConfigFile.return_config_item(config, "Testing", "phpunit_group", "string", "unit")
   phpunit_test_directory = common.ConfigFile.return_config_item(config, "Testing", "phpunit_test_directory", "string", "www/modules/custom")
   phpunit_path = common.ConfigFile.return_config_item(config, "Testing", "phpunit_path", "string", "vendor/phpunit/phpunit/phpunit")
+  # CodeSniffer is Drupal specific, see drupal/DrupalTests.py
+  codesniffer = common.ConfigFile.return_config_item(config, "Testing", "codesniffer", "boolean")
+  codesniffer_extensions = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_extensions", "string", "php,module,inc,install,test,profile,theme,info,txt,md")
+  codesniffer_ignore = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_ignore", "string", "node_modules,bower_components,vendor")
+  codesniffer_paths = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_paths", "string", "www/modules/custom www/modules/theme")
 
   # Set SSH key if needed
   # @TODO: this needs to be moved to config.ini for Code Enigma GitHub projects
@@ -360,7 +366,7 @@ def existing_build_wrapper(url, repo, branch, build, buildtype, alias, site, no_
 @task
 def test_runner(repo, branch, build, alias, buildtype, url, ssl_enabled, config, behat_config, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site):
   # Run simpletest tests
-  execute(DrupalTests.run_tests, repo, branch, build, config)
+  execute(DrupalTests.run_tests, repo, branch, build, config, drupal_version, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths)
 
   # Run behat tests
   if behat_config:

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -50,6 +50,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   previous_build = ""
   previous_db = ""
   statuscake_paused = False
+  www_root = "/var/www"
 
   # Set our host_string based on user@host
   env.host_string = '%s@%s' % (user, env.host)
@@ -97,13 +98,13 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   no_dev = common.ConfigFile.return_config_item(config, "Composer", "no_dev", "boolean", True)
 
   # Can be set in the config.ini [Testing] section
-  # PHPUnit is in 'common' because it can be used for any PHP application
+  # PHPUnit is in common/Tests because it can be used for any PHP application
   phpunit_run = common.ConfigFile.return_config_item(config, "Testing", "phpunit_run", "boolean", False)
   phpunit_fail_build = common.ConfigFile.return_config_item(config, "Testing", "phpunit_fail_build", "boolean", False)
   phpunit_group = common.ConfigFile.return_config_item(config, "Testing", "phpunit_group", "string", "unit")
   phpunit_test_directory = common.ConfigFile.return_config_item(config, "Testing", "phpunit_test_directory", "string", "www/modules/custom")
   phpunit_path = common.ConfigFile.return_config_item(config, "Testing", "phpunit_path", "string", "vendor/phpunit/phpunit/phpunit")
-  # CodeSniffer is Drupal specific, see drupal/DrupalTests.py
+  # CodeSniffer itself is in common/Tests, but standards used here are Drupal specific, see drupal/DrupalTests.py for the wrapper to apply them
   codesniffer = common.ConfigFile.return_config_item(config, "Testing", "codesniffer", "boolean")
   codesniffer_extensions = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_extensions", "string", "php,module,inc,install,test,profile,theme,info,txt,md")
   codesniffer_ignore = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_ignore", "string", "node_modules,bower_components,vendor")
@@ -378,7 +379,8 @@ def test_runner(repo, branch, build, alias, buildtype, url, ssl_enabled, config,
   # Run phpunit tests
   if phpunit_run:
     # @TODO: We really need to figure out how to use execute() and fish returned variables from the response
-    phpunit_tests_failed = common.Tests.run_phpunit_tests(repo, branch, build, phpunit_group, phpunit_test_directory, phpunit_path)
+    path_to_app = "%s/%s_%s_%s" % (www_root, repo, branch, build)
+    phpunit_tests_failed = common.Tests.run_phpunit_tests(path_to_app, phpunit_group, phpunit_test_directory, phpunit_path)
     if phpunit_fail_build and phpunit_tests_failed:
       Revert._revert_db(alias, branch, build)
       Revert._revert_settings(repo, branch, build, site, alias)


### PR DESCRIPTION
Adding CodeSniffer support, which closes #102, and also making a small start on #22 by introducing the 'www-root' param to the run_tests() function.