### PR TITLE
Set the url to None if the build is a multisite build, so the first s…

### DIFF
--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -172,6 +172,9 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   # Just sets to 'default' if it is not
   mapping = {}
   mapping = Drupal.configure_site_mapping(repo, mapping, config)
+  # If this is a multisite build, set the url to None so one is generated for every site in the multisite setup. This particular line will ensure the *first* site has its url generated.
+  if len(mapping) > 1:
+    url = None
   # Run new installs
   for alias,site in mapping.iteritems():
     # Compile variables for feature branch builds (if applicable)


### PR DESCRIPTION
…ite to be deployed has its url generated.