### PR TITLE
Wrap the composer install function in a with shell_env() clause

### DIFF
--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -161,12 +161,13 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
     import_config = False
   if drupal_version > 7 and composer is True:
     # Sometimes people use the Drupal Composer project which puts Drupal 8's composer.json file in repo root.
-    with settings(warn_only=True):
-      if run("find %s/composer.json" % site_root).return_code == 0:
-        path = site_root
-      else:
-        path = site_root + "/www"
-    execute(common.PHP.composer_command, path, "install", None, no_dev, composer_lock)
+    with shell_env(PHPRC='%s' % php_ini_file):
+      with settings(warn_only=True):
+        if run("find %s/composer.json" % site_root).return_code == 0:
+          path = site_root
+        else:
+          path = site_root + "/www"
+      execute(common.PHP.composer_command, path, "install", None, no_dev, composer_lock)
 
   # Compile a site mapping, which is needed if this is a multisite build
   # Just sets to 'default' if it is not


### PR DESCRIPTION
This is so the correct PHP config is used during the `composer install` step.