### PR TITLE
drush runtime location for Drupal version check needs to be build folder

### DIFF
--- a/drupal/DrupalUtils.py
+++ b/drupal/DrupalUtils.py
@@ -50,7 +50,7 @@ def determine_drupal_version(drupal_version, repo, branch, build, config, method
   if drupal_version is None:
     print "===> No drupal_version override in config.ini, so we'll figure out the version of Drupal ourselves"
 
-    drush_runtime_location = "/var/www/live.%s.%s/www/sites/default" % (repo, branch)
+    drush_runtime_location = "%s/www" % drupal_path
     # We're only checking the Drupal version so it's fine to not pass a 'site' and rely on default
     drush_output = drush_command("status", None, drush_runtime_location, False, "yaml")
     if run("echo \"%s\" | grep 'drupal-version'" % drush_output).failed:


### PR DESCRIPTION
Not the live link like it was. Breaks feature branch and initial builds.