### PR TITLE
Fixes #219, adding a regex check

### DIFF
--- a/common/Tests.py
+++ b/common/Tests.py
@@ -88,3 +88,20 @@ def run_codesniffer(path_to_app, extensions="php,inc,txt,md", install=True, stan
   # Run CodeSniffer itself
   with cd("%s" % path_to_app):
     run("/home/jenkins/.composer/vendor/bin/phpcs %s --extensions=%s %s %s" % (standard, extensions, ignore, paths_to_test))
+
+
+# Run a regex check of the site we're building
+@task
+def run_regex_check(url_to_check, string_to_check, check_protocol="https", curl_options="sL", notifications_email=None):
+  print "===> Checking the site is up"
+  if local("curl -%s %s://%s | grep '%s'" % (curl_options, check_protocol, url_to_check, string_to_check)).failed:
+    print "  ################################"
+    print "  ################################"
+    print "    REGEX CHECK FAILED!!"
+    print "  ################################"
+    print "  ################################"
+    if notifications_email:
+      local("echo 'Your regex check for the URL %s  with string check for '%s' has failed, the site may be down. Please check it immediately!' | mail -s 'Site down following deploy' %s" % (url_to_check, string_to_check, notifications_email))
+      print "===> Sent warning email to %s" % notifications_email
+  else:
+    print "===> Site is up"

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -218,7 +218,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
         existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, build, buildtype, previous_build, alias, site, no_dev, config, config_export, drupal_version, readonlymode, notifications_email, autoscale, do_updates, import_config, fra, run_cron, feature_branches, php_ini_file)
 
     # After any build we want to run all the available automated tests
-    test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, config, behat_config, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths)
+    test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, config, behat_config, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email)
 
     # Now everything should be in a good state, let's enable environment indicator for this site, if present
     execute(Drupal.environment_indicator, www_root, repo, branch, build, buildtype, alias, site, drupal_version)

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -117,6 +117,10 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   codesniffer_extensions = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_extensions", "string", "php,module,inc,install,test,profile,theme,info,txt,md")
   codesniffer_ignore = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_ignore", "string", "node_modules,bower_components,vendor")
   codesniffer_paths = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_paths", "string", "www/modules/custom www/themes/custom")
+  # Regex check
+  string_to_check = common.ConfigFile.return_config_item(config, "Testing", "string_to_check", "string")
+  curl_options = common.ConfigFile.return_config_item(config, "Testing", "curl_options", "string", "sL")
+  check_protocol = common.ConfigFile.return_config_item(config, "Testing", "check_protocol", "string", "https")
 
   # Set SSH key if needed
   # @TODO: this needs to be moved to config.ini for Code Enigma GitHub projects
@@ -395,7 +399,7 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
 
 # Wrapper function for runnning automated tests on a site
 @task
-def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, config, behat_config, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths):
+def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, config, behat_config, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email):
   # Run simpletest tests
   execute(DrupalTests.run_tests, repo, branch, build, config, drupal_version, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, www_root)
 
@@ -421,5 +425,9 @@ def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enable
       print "===> phpunit tests ran successfully."
   else:
     print "===> No phpunit tests."
+
+  # Run a regex check
+  if url and string_to_check:
+    common.Tests.run_regex_check(url, string_to_check, check_protocol, curl_options, notifications_email)
 
   execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='post-tests', hosts=env.roledefs['app_all'])


### PR DESCRIPTION
This allows Drupal users to set a regex check to assure themselves a build succeeded. It runs at the end of the tests section and optionally sends an email too. You may pass it cURL options, by default it uses -sL (silent and follow redirects).