### PR TITLE
Issue 247 - set default result file behaviour for sql-dump

### DIFF
--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -185,8 +185,9 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
     if freshinstall:
       print "===> Database to get a fresh dump from is on the same server. Getting database dump now..."
       # Time to dump the database and save it to db/
-      dump_file = "%s_%s.sql" % (alias, syncbranch)
-      run('drush @%s_%s sql-dump --result-file=/var/www/%s_%s_%s/db/%s | bzip2 -f > /var/www/%s_%s_%s/db/%s.bz2' % (alias, syncbranch, repo, branch, build, dump_file, repo, branch, build, dump_file))
+      file_name = "%s_%s.sql" % (alias, syncbranch)
+      run('drush @%s_%s sql-dump --result-file=/var/www/%s_%s_%s/db/%s | bzip2 -f > /var/www/%s_%s_%s/db/%s.bz2' % (alias, syncbranch, repo, branch, build, file_name, repo, branch, build, file_name))
+      dump_file = "%s.bz2" % (file_name)
     else:
       # Because freshinstall is False and the site we're syncing from is on the same server,
       # we can use drush sql-sync to sync that database to this one

--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -212,7 +212,7 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
 
     if sanitise == "yes":
       script_dir = os.path.dirname(os.path.realpath(__file__))
-      dump_file = 'custombranch_%s_%s.sql' % (alias, now)
+      file_name = 'custombranch_%s_%s.sql' % (alias, now)
       if put(script_dir + '/../util/drupal-obfuscate.rb', '/home/jenkins', mode=0755).failed:
         raise SystemExit("######## Could not copy the obfuscate script to the application server, aborting as we cannot safely sanitise the live data")
       else:
@@ -222,9 +222,9 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
           dbuser = run("drush @%s_%s status  Database\ user | awk {'print $4'} | head -1" % (alias, syncbranch))
           dbpass = run("drush @%s_%s --show-passwords status  Database\ pass | awk {'print $4'} | head -1" % (alias, syncbranch))
           dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (alias, syncbranch))
-          run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /home/jenkins/drupal-obfuscate.rb | bzip2 -f > ~jenkins/dbbackups/%s.bz2' % (dbuser, dbpass, dbhost, dbname, dump_file))
+          run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /home/jenkins/drupal-obfuscate.rb | bzip2 -f > ~jenkins/dbbackups/%s.bz2' % (dbuser, dbpass, dbhost, dbname, file_name))
     else:
-      run('drush @%s_%s sql-dump --result-file=~jenkins/dbbackups/%s | bzip2 -f > ~jenkins/dbbackups/%s.bz2' % (alias, syncbranch, dump_file, dump_file))
+      run('drush @%s_%s sql-dump --result-file=~jenkins/dbbackups/%s | bzip2 -f > ~jenkins/dbbackups/%s.bz2' % (alias, syncbranch, file_name, file_name))
 
     print "===> Fetching the database from the remote server..."
     dump_file = "custombranch_%s_%s_from_%s.sql.bz2" % (alias, now, syncbranch)

--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -185,8 +185,8 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
     if freshinstall:
       print "===> Database to get a fresh dump from is on the same server. Getting database dump now..."
       # Time to dump the database and save it to db/
-      dump_file = "%s_%s.sql.bz2" % (alias, syncbranch)
-      run('drush @%s_%s sql-dump | bzip2 -f > /var/www/%s_%s_%s/db/%s' % (alias, syncbranch, repo, branch, build, dump_file))
+      dump_file = "%s_%s.sql" % (alias, syncbranch)
+      run('drush @%s_%s sql-dump --gzip --result-file=/var/www/%s_%s_%s/db/%s' % (alias, syncbranch, repo, branch, build, dump_file))
     else:
       # Because freshinstall is False and the site we're syncing from is on the same server,
       # we can use drush sql-sync to sync that database to this one
@@ -222,7 +222,7 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
           dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (alias, syncbranch))
           run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /home/jenkins/drupal-obfuscate.rb | bzip2 -f > ~jenkins/dbbackups/custombranch_%s_%s.sql.bz2' % (dbuser, dbpass, dbhost, dbname, alias, now))
     else:
-      run('drush @%s_%s sql-dump | bzip2 -f > ~jenkins/dbbackups/custombranch_%s_%s.sql.bz2' % (alias, syncbranch, alias, now))
+      run('drush @%s_%s sql-dump --gzip --result-file=~jenkins/dbbackups/custombranch_%s_%s.sql' % (alias, syncbranch, alias, now))
 
     print "===> Fetching the database from the remote server..."
     dump_file = "custombranch_%s_%s_from_%s.sql.bz2" % (alias, now, syncbranch)

--- a/drupal/DrupalUtils.py
+++ b/drupal/DrupalUtils.py
@@ -91,8 +91,8 @@ def get_database(shortname, branch, santise):
       dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (shortname, branch))
       run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /usr/local/bin/drupal-obfuscate.rb | bzip2 -f > ~jenkins/client-db-dumps/%s-%s_database_dump.sql.bz2' % (dbuser, dbpass, dbhost, dbname, shortname, branch))
   else:
-      dump_file = "%s_%s_database_dump.sql" % (shortname, branch)
-      run('drush @%s_%s sql-dump --result-file=%s | bzip2 -f > ~jenkins/client-db-dumps/%s.bz2' % (shortname, branch, dump_file, dump_file))
+    dump_file = "%s_%s_database_dump.sql" % (shortname, branch)
+    run('drush @%s_%s sql-dump --result-file=%s | bzip2 -f > ~jenkins/client-db-dumps/%s.bz2' % (shortname, branch, dump_file, dump_file))
 
   # Make sure a directory exists for database dumps to be downloaded to
   local('mkdir -p /tmp/client-db-dumps')

--- a/drupal/DrupalUtils.py
+++ b/drupal/DrupalUtils.py
@@ -91,7 +91,8 @@ def get_database(shortname, branch, santise):
       dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (shortname, branch))
       run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /usr/local/bin/drupal-obfuscate.rb | bzip2 -f > ~jenkins/client-db-dumps/%s-%s_database_dump.sql.bz2' % (dbuser, dbpass, dbhost, dbname, shortname, branch))
   else:
-    run('drush @%s_%s sql-dump | bzip2 -f > ~jenkins/client-db-dumps/%s-%s_database_dump.sql.bz2' % (shortname, branch, shortname, branch))
+      dump_file = "%s_%s_database_dump.sql" % (shortname, branch)
+      run('drush @%s_%s sql-dump --result-file=%s | bzip2 -f > ~jenkins/client-db-dumps/%s.bz2' % (shortname, branch, dump_file, dump_file))
 
   # Make sure a directory exists for database dumps to be downloaded to
   local('mkdir -p /tmp/client-db-dumps')

--- a/drupal/Multisite.py
+++ b/drupal/Multisite.py
@@ -60,7 +60,7 @@ def configure_site_mapping(repo, mapping, config):
         else:
           alias = "%s_%s" % (repo, buildsite)
         mapping.update({alias:buildsite})
-  
+
   print "Final mapping is: %s" % mapping
   return mapping
 
@@ -366,7 +366,7 @@ def backup_db(repo, branch, build, mapping, sites):
     if buildsite not in sites:
       print "===> Taking a database backup..."
       with settings(warn_only=True):
-        if run("drush @%s_%s sql-dump --skip-tables-key=common | gzip > ~jenkins/dbbackups/%s_%s_prior_to_%s.sql.gz; if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; else exit 0; fi" % (alias, branch, alias, branch, build)).failed:
+        if run("drush @%s_%s sql-dump --skip-tables-key=common --gzip --result-file=~jenkins/dbbackups/%s_%s_prior_to_%s.sql; if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; else exit 0; fi" % (alias, branch, alias, branch, build)).failed:
           failed_backup = True
         else:
           failed_backup = False
@@ -409,7 +409,7 @@ def adjust_settings_php(repo, branch, build, buildtype, mapping, sites):
 
   for alias,buildsite in mapping.iteritems():
     if buildsite not in sites:
-      
+
       # In some cases it seems jenkins loses write permissions to the 'default' directory
       # Let's make sure!
       sudo("chmod -R 775 /var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, buildsite))
@@ -570,7 +570,7 @@ def drush_status(repo, branch, build, buildtype, mapping, sites, revert=False, r
                 _revert_db(alias, branch, build)
                 _revert_settings(repo, alias, branch, build, buildtype, buildsite)
             raise SystemExit("Could not bootstrap the database on this build! Aborting")
-       
+
           if run("drush status").failed:
             if revert == False and revert_settings == True:
               _revert_settings(repo, alias, branch, build, buildtype, buildsite)

--- a/drupal/Sync.py
+++ b/drupal/Sync.py
@@ -149,8 +149,8 @@ def sync_db(orig_host, shortname, staging_shortname, staging_branch, prod_branch
           dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (shortname, prod_branch))
           run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /home/jenkins/drupal-obfuscate.rb | bzip2 -f > ~jenkins/dbbackups/drupal_%s_%s.sql.bz2' % (dbuser, dbpass, dbhost, dbname, shortname, now))
     else:
-        dump_file = "drupal_%s_%s.sql" % (shortname, now)
-        run('drush @%s_%s sql-dump --result-file=%s | bzip2 -f > ~jenkins/dbbackups/%s.bz2' % (shortname, prod_branch, dump_file, dump_file))
+      dump_file = "drupal_%s_%s.sql" % (shortname, now)
+      run('drush @%s_%s sql-dump --result-file=%s | bzip2 -f > ~jenkins/dbbackups/%s.bz2' % (shortname, prod_branch, dump_file, dump_file))
     print "===> Fetching the drupal database backup from production..."
 
   # Fetch the database backup from prod


### PR DESCRIPTION
Original issue was #247 

Initially raised this as an issue in our internal issue tracking with CE, but it seems like a more widespread issue, so sensible to raise here instead.

There's a line in the deployment scripts that runs `drush sql-dump` and pipes the output into a bzip file:

    [jenkins@server] run: drush @site_environment sql-dump | bzip2 -f > /var/www/target_branch/db/site_environment.sql.bz2

With Drush 8, that worked fine - `sql-dump`, with no flags, printed raw SQL to the command line ready to be piped into a file.

With Drush 9, the `--result-file` flag is now required. See related issue where someone has mentioned this: https://github.com/drush-ops/drush/issues/3364

To get around this problem, we have added the following to our `drush.yml` file: 

    commands:
      sql:
        dump:
          options:
            result-file: auto

This adds `--result-file auto` every time we run `sql:dump` (including when these builds are run, and locally), ensuring we get a file dumped to our home directories. 

In summary: 

* `drush sql:dump` now requires the `--result-file` flag with a value, otherwise it errors and fails to dump a file 
* Adding `--result-file auto` saves a file and prints a message to the screen, which is picked up by your scripts and piped into a bz2 file
* Turns out that message is not valid SQL, so the script struggles to import it later on in the process

Do we remove it from our `drush.yml` and let you fix it? Do the CE scripts need to be updated so they use the result file (and clean up afterwards)? 

Pull request attached, I did try using `--gzip` flags for some things but there were so many instances where names of files changed that I just got confused and left it all as bzip2 files.