### PR TITLE
[WIP] Override ssh_key setting

### DIFF
--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -31,7 +31,7 @@ global config
 
 # Main build script
 @task
-def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, freshdatabase="Yes", syncbranch=None, sanitise="no", import_config=False, statuscakeuser=None, statuscakekey=None, statuscakeid=None, restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', mysql_version=5.5, rds=False, autoscale=None, mysql_config='/etc/mysql/debian.cnf', config_filename='config.ini', php_ini_file=None):
+def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, freshdatabase="Yes", syncbranch=None, sanitise="no", import_config=False, statuscakeuser=None, statuscakekey=None, statuscakeid=None, restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', mysql_version=5.5, rds=False, autoscale=None, mysql_config='/etc/mysql/debian.cnf', config_filename='config.ini', php_ini_file=None, ssh_key_override=False):
 
   # Read the config.ini file from repo, if it exists
   config = common.ConfigFile.buildtype_config_file(buildtype, config_filename)
@@ -125,7 +125,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
 
   # Set SSH key if needed
   # @TODO: this needs to be moved to config.ini for Code Enigma GitHub projects
-  if "git@github.com" in repourl:
+  if "git@github.com" in repourl and not ssh_key_override:
     ssh_key = "/var/lib/jenkins/.ssh/id_rsa_github"
 
   # Prepare Behat variables


### PR DESCRIPTION
If a repo URL has github.com in the address, the ssh_key is set to our GitHub key, which isn't ideal, even if ssh_key is set in config.ini.

This change should allow us to override that by setting ssh_key_override to True in the Jenkins job (not in config.ini). Or should it be done via config.ini?