### PR TITLE
drush 9 compatibility

### DIFF
--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -186,7 +186,7 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
       print "===> Database to get a fresh dump from is on the same server. Getting database dump now..."
       # Time to dump the database and save it to db/
       dump_file = "%s_%s.sql.bz2" % (alias, syncbranch)
-      run('drush @%s_%s sql-dump | bzip2 -f > /var/www/%s_%s_%s/db/%s' % (alias, syncbranch, repo, branch, build, dump_file))
+      run('drush @%s_%s sql-dump --result-file=/dev/stdout | bzip2 -f > /var/www/%s_%s_%s/db/%s' % (alias, syncbranch, repo, branch, build, dump_file))
     else:
       # Because freshinstall is False and the site we're syncing from is on the same server,
       # we can use drush sql-sync to sync that database to this one
@@ -222,7 +222,7 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
           dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (alias, syncbranch))
           run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /home/jenkins/drupal-obfuscate.rb | bzip2 -f > ~jenkins/dbbackups/custombranch_%s_%s.sql.bz2' % (dbuser, dbpass, dbhost, dbname, alias, now))
     else:
-      run('drush @%s_%s sql-dump | bzip2 -f > ~jenkins/dbbackups/custombranch_%s_%s.sql.bz2' % (alias, syncbranch, alias, now))
+      run('drush @%s_%s sql-dump --result-file=/dev/stdout | bzip2 -f > ~jenkins/dbbackups/custombranch_%s_%s.sql.bz2' % (alias, syncbranch, alias, now))
 
     print "===> Fetching the database from the remote server..."
     dump_file = "custombranch_%s_%s_from_%s.sql.bz2" % (alias, now, syncbranch)

--- a/drupal/DrupalUtils.py
+++ b/drupal/DrupalUtils.py
@@ -91,7 +91,7 @@ def get_database(shortname, branch, santise):
       dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (shortname, branch))
       run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /usr/local/bin/drupal-obfuscate.rb | bzip2 -f > ~jenkins/client-db-dumps/%s-%s_database_dump.sql.bz2' % (dbuser, dbpass, dbhost, dbname, shortname, branch))
   else:
-    run('drush @%s_%s sql-dump | bzip2 -f > ~jenkins/client-db-dumps/%s-%s_database_dump.sql.bz2' % (shortname, branch, shortname, branch))
+    run('drush @%s_%s sql-dump --result-file=/dev/stdout | bzip2 -f > ~jenkins/client-db-dumps/%s-%s_database_dump.sql.bz2' % (shortname, branch, shortname, branch))
 
   # Make sure a directory exists for database dumps to be downloaded to
   local('mkdir -p /tmp/client-db-dumps')

--- a/drupal/Multisite.py
+++ b/drupal/Multisite.py
@@ -366,7 +366,7 @@ def backup_db(repo, branch, build, mapping, sites):
     if buildsite not in sites:
       print "===> Taking a database backup..."
       with settings(warn_only=True):
-        if run("drush @%s_%s sql-dump --skip-tables-key=common | gzip > ~jenkins/dbbackups/%s_%s_prior_to_%s.sql.gz; if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; else exit 0; fi" % (alias, branch, alias, branch, build)).failed:
+        if run("drush @%s_%s sql-dump --result-file=/dev/stdout --skip-tables-key=common | gzip > ~jenkins/dbbackups/%s_%s_prior_to_%s.sql.gz; if [ ${PIPESTATUS[0]} -ne 0 ]; then exit 1; else exit 0; fi" % (alias, branch, alias, branch, build)).failed:
           failed_backup = True
         else:
           failed_backup = False

--- a/drupal/Sync.py
+++ b/drupal/Sync.py
@@ -17,7 +17,7 @@ def backup_db(shortname, staging_branch):
   print "===> Ensuring backup directory exists"
   run("mkdir -p ~jenkins/dbbackups")
   print "===> Taking a database backup of the Drupal database..."
-  run("drush @%s_%s sql-dump | bzip2 -f > ~jenkins/dbbackups/%s_%s_prior_to_sync_%s.sql.bz2" % (shortname, staging_branch, shortname, staging_branch, now))
+  run("drush @%s_%s sql-dump --result-file=/dev/stdout | bzip2 -f > ~jenkins/dbbackups/%s_%s_prior_to_sync_%s.sql.bz2" % (shortname, staging_branch, shortname, staging_branch, now))
 
 
 # Sync uploaded assets from production to staging
@@ -148,7 +148,7 @@ def sync_db(orig_host, shortname, staging_shortname, staging_branch, prod_branch
           dbhost = run("drush @%s_%s status  Database\ host | awk {'print $4'} | head -1" % (shortname, prod_branch))
           run('mysqldump --single-transaction -c --opt -Q --hex-blob -u%s -p%s -h%s %s | /home/jenkins/drupal-obfuscate.rb | bzip2 -f > ~jenkins/dbbackups/drupal_%s_%s.sql.bz2' % (dbuser, dbpass, dbhost, dbname, shortname, now))
     else:
-      run('drush @%s_%s sql-dump | bzip2 -f > ~jenkins/dbbackups/drupal_%s_%s.sql.bz2' % (shortname, prod_branch, shortname, now))
+      run('drush @%s_%s sql-dump --result-file=/dev/stdout | bzip2 -f > ~jenkins/dbbackups/drupal_%s_%s.sql.bz2' % (shortname, prod_branch, shortname, now))
     print "===> Fetching the drupal database backup from production..."
 
   # Fetch the database backup from prod

--- a/wordpress/WordPress.py
+++ b/wordpress/WordPress.py
@@ -69,7 +69,7 @@ def wp_updatedb(repo, branch, build):
 #  _sshagent_run("cd /var/www/%s_%s_%s && git branch -f dbbackups && git push origin dbbackups" % (repo, branch, build))
   # If it *did* already exist, we need to pull the latest changes or else we'll get a conflict if we do this after we make a new dump
 #  _sshagent_run("cd /var/www/%s_%s_%s && git pull origin dbbackups" % (repo, branch, build))
-#  run("drush @%s_%s sql-dump | bzip2 -f > /var/www/%s_%s_%s/db/%s.%s.sql.bz2" % (repo, branch, repo, branch, build, repo, branch))
+#  run("drush @%s_%s sql-dump --result-file=/dev/stdout | bzip2 -f > /var/www/%s_%s_%s/db/%s.%s.sql.bz2" % (repo, branch, repo, branch, build, repo, branch))
 #  with cd("/var/www/live.%s.%s" % (repo, branch)):
 #    run("git add db/%s.%s.sql.bz2" % (repo, branch))
 #    run("git commit -m \"New database dump taken after successful %s build %s\"" % (branch, build))


### PR DESCRIPTION
We're seeing issues with drush 9 and the deployment scripts (specifically regarding sql-dump), that cause feature branch builds to fail.

The issue occurs because in drush 9 `drush sql-dump` no longer dumps to stdout by default, rather it dumps to an arbitrary file (who thought this was a good idea!?).

( https://github.com/drush-ops/drush/issues/3364 is related)

My suggested fix is to append `--result-file=/dev/stdout` too all occurences of sql-dump in the scripts. The nice thing about doing it this way is it retains compatibility with older versions of drush.

This PR should supercede https://github.com/codeenigma/deployments/pull/248
