### PR TITLE
Update previous build fetch

### DIFF
--- a/common/Utils.py
+++ b/common/Utils.py
@@ -74,7 +74,8 @@ def get_previous_build(repo, branch, build):
     if run("readlink /var/www/live.%s.%s" % (repo, branch)).failed:
       return None
     else:
-      return run("readlink /var/www/live.%s.%s" % (repo, branch))
+      with cd("/var/www/live.%s.%s" % (repo, branch)):
+        return run("pwd -P")
 
 @task
 def get_previous_db(repo, branch, build):

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -31,7 +31,7 @@ global config
 
 # Main build script
 @task
-def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, freshdatabase="Yes", syncbranch=None, sanitise="no", import_config=False, statuscakeuser=None, statuscakekey=None, statuscakeid=None, restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', mysql_version=5.5, rds=False, autoscale=None, mysql_config='/etc/mysql/debian.cnf', config_filename='config.ini', php_ini_file=None, ssh_key_override=False):
+def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, freshdatabase="Yes", syncbranch=None, sanitise="no", import_config=False, statuscakeuser=None, statuscakekey=None, statuscakeid=None, restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', mysql_version=5.5, rds=False, autoscale=None, mysql_config='/etc/mysql/debian.cnf', config_filename='config.ini', php_ini_file=None):
 
   # Read the config.ini file from repo, if it exists
   config = common.ConfigFile.buildtype_config_file(buildtype, config_filename)
@@ -125,7 +125,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
 
   # Set SSH key if needed
   # @TODO: this needs to be moved to config.ini for Code Enigma GitHub projects
-  if "git@github.com" in repourl and not ssh_key_override:
+  if "git@github.com" in repourl:
     ssh_key = "/var/lib/jenkins/.ssh/id_rsa_github"
 
   # Prepare Behat variables

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -31,7 +31,7 @@ global config
 
 # Main build script
 @task
-def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, freshdatabase="Yes", syncbranch=None, sanitise="no", import_config=False, statuscakeuser=None, statuscakekey=None, statuscakeid=None, restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', mysql_version=5.5, rds=False, autoscale=None, mysql_config='/etc/mysql/debian.cnf', config_filename='config.ini', php_ini_file=None):
+def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, freshdatabase="Yes", syncbranch=None, sanitise="no", import_config=False, statuscakeuser=None, statuscakekey=None, statuscakeid=None, restartvarnish="yes", cluster=False, sanitised_email=None, sanitised_password=None, webserverport='8080', mysql_version=5.5, rds=False, autoscale=None, mysql_config='/etc/mysql/debian.cnf', config_filename='config.ini', php_ini_file=None, ssh_key_override=False):
 
   # Read the config.ini file from repo, if it exists
   config = common.ConfigFile.buildtype_config_file(buildtype, config_filename)
@@ -125,7 +125,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
 
   # Set SSH key if needed
   # @TODO: this needs to be moved to config.ini for Code Enigma GitHub projects
-  if "git@github.com" in repourl:
+  if "git@github.com" in repourl and not ssh_key_override:
     ssh_key = "/var/lib/jenkins/.ssh/id_rsa_github"
 
   # Prepare Behat variables


### PR DESCRIPTION
Fixes #251 by ensuring we're in the previous directory, after checking the symlink exists. Then, return the output of `pwd -P` rather than reading the actual symlink.