### PR TITLE
Allow different build hook versions

### DIFF
--- a/common/Utils.py
+++ b/common/Utils.py
@@ -347,7 +347,7 @@ def detect_malicious_strings(malicious_strings, input_string=None, check_locatio
 # Ultimately we can remove entirely and just use buildtype, once
 # Drupal scripts are repaired.
 @task
-def perform_client_deploy_hook(repo, build_path, build, buildtype, config, stage):
+def perform_client_deploy_hook(repo, build_path, build, buildtype, config, stage, build_hook_version="1", alias=None, site=None):
   cwd = os.getcwd()
   print "===> Looking for custom developer hooks at the %s stage for %s builds" % (stage, buildtype)
 
@@ -386,14 +386,19 @@ def perform_client_deploy_hook(repo, build_path, build, buildtype, config, stage
             print "===> Executing Fabric script %s" % option
             hook_file = '%s/build-hooks/%s' % (cwd, option)
 
+            if build_hook_version == "1":
+              fab_command = "fab -H %s -f %s main:repo=%s,branch=%s,build=%s" % (env.host, hook_file, repo, build_path, build)
+            else:
+              fab_command = "fab -H %s -f %s main:repo=%s,branch=%s,build=%s,alias=%s,site=%s" % (env.host, hook_file, repo, build_path, build, alias, site)
+
             if stage != 'pre':
               with settings(warn_only=True):
-                if local("fab -H %s -f %s main:repo=%s,branch=%s,build=%s" % (env.host, hook_file, repo, build_path, build)).failed:
+                if local("%s" % fab_command).failed:
                   print "Could not run build hook. Uh oh."
                 else:
                   print "Finished running build hook."
             else:
-              if local("fab -H %s -f %s main:repo=%s,branch=%s,build=%s" % (env.host, hook_file, repo, build_path, build)).failed:
+              if local("%s" % fab_command).failed:
                 print "Could not run build hook. Uh oh."
               else:
                 print "Finished running build hook."


### PR DESCRIPTION
First attempt at doing this, which could be improved in the future, potentially. This is so we can use build hooks on multisite setups. In our case, stage_file_proxy needs to be enabled on each site in the setup in a post-build hook, but as we weren't passing the site name to the build hooks, it was not possible.

I've done it this way so already existing build hooks won't break (at least, they _shouldn't_ break). The build_hook_version will default to **1**. Multisite clients who want to use build hooks will need to set that to **2** in their config.ini file.