### PR TITLE
Reset env.host after fetching a database dump

### DIFF
--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -239,6 +239,9 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
       # For now custombranch builds to clusters cannot work
       dump_file = Drupal.prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, env.host_string, sanitise, sanitised_password, sanitised_email)
 
+      # Need to make sure the env.host variable is set correctly, after potentially fetching a database dump from production
+      env.host = env.roledefs['app_primary']
+
     if FeatureBranches.featurebranch_url is not None:
       url = FeatureBranches.featurebranch_url
 


### PR DESCRIPTION
When a feature branch build uses the production site to grab a database from, the `env.host` variable is set to the production host. The variable is then left untouched, so when the URL is created for the feature branch site, it's using the production host rather than the development host, which is incorrect.

This change will ensure the env.host variable is reset to the correct value, as the env.roledefs is populated **before** the database is fetched.