### PR TITLE
Adding ability to use CMI Tools for config management

### DIFF
--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -5,6 +5,7 @@ import string
 import datetime
 # Custom Code Enigma modules
 import DrupalUtils
+import DrupalConfig
 import common.ConfigFile
 import common.Services
 import common.Utils
@@ -471,10 +472,7 @@ def config_import(repo, branch, build, buildtype, site, alias, drupal_version, i
   with settings(warn_only=True):
     # Check to see if this is a Drupal 8 build
     if drupal_version > 7:
-      if import_config_method == "cimy":
-        import_config_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
-      else:
-        import_config_command = "cim"
+      import_config_command = DrupalConfig.import_config_command(repo, branch, build, site, import_config_method, cimy_mapping)
 
       print "===> Importing configuration for Drupal 8 site..."
       drush_runtime_location = "/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)

--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -467,13 +467,18 @@ def environment_indicator(www_root, repo, branch, build, buildtype, alias, site,
 # Function used by Drupal 8 builds to import site config
 @task
 @roles('app_primary')
-def config_import(repo, branch, build, buildtype, site, alias, drupal_version, previous_build, sites_deployed=None):
+def config_import(repo, branch, build, buildtype, site, alias, drupal_version, import_config_method, cimy_mapping, previous_build, sites_deployed=None):
   with settings(warn_only=True):
     # Check to see if this is a Drupal 8 build
     if drupal_version > 7:
+      if import_config_method == "cimy":
+        import_config_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
+      else:
+        import_config_command = "cim"
+
       print "===> Importing configuration for Drupal 8 site..."
       drush_runtime_location = "/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)
-      if DrupalUtils.drush_command("cim", site, drush_runtime_location, True, None, None, True).failed:
+      if DrupalUtils.drush_command("%s" % import_config_command, site, drush_runtime_location, True, None, None, True).failed:
         print "###### Could not import configuration! Reverting this database and settings"
         for revert_alias,revert_site in sites_deployed.iteritems():
           execute(Revert._revert_db, repo, branch, build, buildtype, revert_site)

--- a/drupal/DrupalConfig.py
+++ b/drupal/DrupalConfig.py
@@ -20,6 +20,20 @@ def configure_cimy_params(config, site):
 
 
 @task
+def import_config_command(repo, branch, build, site, import_config_method, cimy_mapping):
+  if import_config_method == "cimy":
+    if not check_cmi_tools_exists(repo, branch, build, site):
+      import_config_method = "cim"
+
+  if import_config_method == "cimy":
+    return_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
+  else:
+    return_command = "cim"
+
+  return return_command
+
+
+@task
 def check_cmi_tools_exists(repo, branch, build, site):
   with settings(warn_only=True):
     with cd("/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)):

--- a/drupal/DrupalConfig.py
+++ b/drupal/DrupalConfig.py
@@ -1,0 +1,34 @@
+from fabric.api import *
+import DrupalUtils
+import common.ConfigFile
+import common.Utils
+
+@task
+def configure_cimy_params(config, buildtype):
+  cimy_mapping = {}
+
+  cimy_source_default = "../config/sync"
+  cimy_delete_default = "../drush/config-delete.yml"
+  cimy_install_default = "../config_install/"
+
+  cimy_mapping['source'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_source" % buildtype, "string", cimy_source_default)
+  cimy_mapping['delete'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_delete" % buildtype, "string", cimy_delete_default)
+  cimy_mapping['install'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_install" % buildtype, "string", cimy_install_default)
+
+  print "Final cimy_mapping is: %s" % cimy_mapping
+
+  return cimy_mapping
+
+
+@task
+def check_cmi_tools_exists(repo, branch, build, site):
+  with settings(warn_only=True):
+    drush_runtime_location = "/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)
+    cmi_tools_exists_output = DrupalUtils.drush_command("pm-list", drush_site=None, drush_runtime_location=drush_runtime_location)
+
+    if run("grep \"drush_cmi_tools\" %s" % cmi_tools_exists_output).return_code == 0:
+      print "##### CMI Tools is installed, so we'll use it."
+      return True
+    else:
+      print "##### CMI Tools is not installed, so we'll need to revert back to using the default config import tool."
+      return False

--- a/drupal/DrupalConfig.py
+++ b/drupal/DrupalConfig.py
@@ -1,5 +1,4 @@
 from fabric.api import *
-import DrupalUtils
 import common.ConfigFile
 import common.Utils
 
@@ -23,12 +22,11 @@ def configure_cimy_params(config, site):
 @task
 def check_cmi_tools_exists(repo, branch, build, site):
   with settings(warn_only=True):
-    drush_runtime_location = "/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)
-    cmi_tools_exists_output = DrupalUtils.drush_command("pm-list", drush_site=None, drush_runtime_location=drush_runtime_location)
+    with cd("/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)):
 
-    if run("grep \"drush_cmi_tools\" %s" % cmi_tools_exists_output).return_code == 0:
-      print "##### CMI Tools is installed, so we'll use it."
-      return True
-    else:
-      print "##### CMI Tools is not installed, so we'll need to revert back to using the default config import tool."
-      return False
+      if run("drush | grep \"drush_cmi_tools\"").return_code == 0:
+        print "##### CMI Tools is installed, so we'll use it."
+        return True
+      else:
+        print "##### CMI Tools is not installed, so we'll need to revert back to using the default config import tool."
+        return False

--- a/drupal/DrupalConfig.py
+++ b/drupal/DrupalConfig.py
@@ -4,16 +4,16 @@ import common.ConfigFile
 import common.Utils
 
 @task
-def configure_cimy_params(config, buildtype):
+def configure_cimy_params(config, site):
   cimy_mapping = {}
 
   cimy_source_default = "../config/sync"
   cimy_delete_default = "../drush/config-delete.yml"
   cimy_install_default = "../config_install/"
 
-  cimy_mapping['source'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_source" % buildtype, "string", cimy_source_default)
-  cimy_mapping['delete'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_delete" % buildtype, "string", cimy_delete_default)
-  cimy_mapping['install'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_install" % buildtype, "string", cimy_install_default)
+  cimy_mapping['source'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_source" % site, "string", cimy_source_default)
+  cimy_mapping['delete'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_delete" % site, "string", cimy_delete_default)
+  cimy_mapping['install'] = common.ConfigFile.return_config_item(config, "Drupal", "%s_cimy_install" % site, "string", cimy_install_default)
 
   print "Final cimy_mapping is: %s" % cimy_mapping
 

--- a/drupal/DrupalTests.py
+++ b/drupal/DrupalTests.py
@@ -5,6 +5,7 @@ import os
 import common.Tests
 import common.PHP
 import DrupalUtils
+import DrupalConfig
 
 
 # Builds the variables needed to carry out Behat testing later
@@ -210,10 +211,7 @@ def reenable_modules(repo, alias, branch, build, site, buildtype, import_config,
   with settings(warn_only=True):
     if drupal_version > 7:
       if import_config:
-        if import_config_method == "cimy":
-          import_config_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
-        else:
-          import_config_command = "cim"
+        import_config_command = DrupalConfig.import_config_command(repo, branch, build, site, import_config_method, cimy_mapping)
         if DrupalUtils.drush_command("%s" % import_config_command, site, drush_runtime_location).failed:
           print "###### Cannot import config to enable modules. Manual investigation is required."
         else:

--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -3,6 +3,7 @@ from fabric.contrib.files import sed
 import string
 # Custom Code Enigma modules
 import DrupalUtils
+import DrupalConfig
 import Drupal
 
 

--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -33,15 +33,7 @@ def initial_db_and_config(repo, branch, build, site, import_config, import_confi
 
     # Import config
     if drupal_version > 7 and import_config:
-      if import_config_method == "cimy":
-        cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
-        if not cmi_tools:
-          import_config_method = "cim"
-
-      if import_config_method == "cimy":
-        import_config_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
-      else:
-        import_config_command = "cim"
+      import_config_command = DrupalConfig.import_config_command(repo, branch, build, site, import_config_method, cimy_mapping)
 
       print "===> Importing configuration for Drupal 8 site..."
       if DrupalUtils.drush_command("%s" % import_config_command, site, drush_runtime_location, True, None, None, True).failed:

--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -16,7 +16,7 @@ drupal_common_config = None
 # Feature branches only, preparing database
 # Assumes single server, cannot work on a cluster
 @task
-def initial_db_and_config(repo, branch, build, site, import_config, drupal_version):
+def initial_db_and_config(repo, branch, build, site, import_config, import_config_method, cimy_mapping, drupal_version):
   with settings(warn_only=True):
     # Run database updates
     drush_runtime_location = "/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)
@@ -32,8 +32,18 @@ def initial_db_and_config(repo, branch, build, site, import_config, drupal_versi
 
     # Import config
     if drupal_version > 7 and import_config:
+      if import_config_method == "cimy":
+        cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
+        if not cmi_tools:
+          import_config_method = "cim"
+
+      if import_config_method == "cimy":
+        import_config_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
+      else:
+        import_config_command = "cim"
+
       print "===> Importing configuration for Drupal 8 site..."
-      if DrupalUtils.drush_command("cim", site, drush_runtime_location, True, None, None, True).failed:
+      if DrupalUtils.drush_command("%s" % import_config_command, site, drush_runtime_location, True, None, None, True).failed:
         raise SystemExit("###### Could not import configuration! Failing build.")
       else:
         print "===> Configuration imported. Running a cache rebuild..."

--- a/drupal/InitialBuild.py
+++ b/drupal/InitialBuild.py
@@ -67,14 +67,19 @@ def initial_build_updatedb(repo, branch, build, site, drupal_version):
 # Function used by Drupal 8 builds to import site config
 @task
 @roles('app_primary')
-def initial_build_config_import(repo, branch, build, site, drupal_version):
+def initial_build_config_import(repo, branch, build, site, drupal_version, import_config_method, cimy_mapping):
   with settings(warn_only=True):
     # Check to see if this is a Drupal 8 build
     if drupal_version > 7:
+      if import_config_method == "cimy":
+        import_config_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
+      else:
+        import_config_command = "cim"
+
       # Set drush location
       drush_runtime_location = "/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)
       print "===> Importing configuration for Drupal 8 site..."
-      if DrupalUtils.drush_command("cim", site, drush_runtime_location, True, None, None, True).failed:
+      if DrupalUtils.drush_command("%s" % import_config_command, site, drush_runtime_location, True, None, None, True).failed:
         raise SystemExit("###### Could not import configuration! Failing the initial build.")
       else:
         print "===> Configuration imported."

--- a/drupal/InitialBuild.py
+++ b/drupal/InitialBuild.py
@@ -6,6 +6,7 @@ import string
 import time
 # Custom Code Enigma modules
 import DrupalUtils
+import DrupalConfig
 import common.Utils
 import common.MySQL
 
@@ -71,10 +72,7 @@ def initial_build_config_import(repo, branch, build, site, drupal_version, impor
   with settings(warn_only=True):
     # Check to see if this is a Drupal 8 build
     if drupal_version > 7:
-      if import_config_method == "cimy":
-        import_config_command = "cimy --source=%s --delete-list=%s --install=%s" % (cimy_mapping['source'], cimy_mapping['delete'], cimy_mapping['install'])
-      else:
-        import_config_command = "cim"
+      import_config_command = DrupalConfig.import_config_command(repo, branch, build, site, import_config_method, cimy_mapping)
 
       # Set drush location
       drush_runtime_location = "/var/www/%s_%s_%s/www/sites/%s" % (repo, branch, build, site)

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -382,10 +382,6 @@ def initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profi
       execute(InitialBuild.initial_build_updatedb, repo, branch, build, site, drupal_version)
       execute(Drupal.drush_clear_cache, repo, branch, build, site, drupal_version)
       if import_config:
-        if import_config_method == "cimy":
-          cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
-          if not cmi_tools:
-            import_config_method = "cim"
         execute(InitialBuild.initial_build_config_import, repo, branch, build, site, drupal_version, import_config_method, cimy_mapping)
         execute(Drupal.drush_clear_cache, repo, branch, build, site, drupal_version)
 
@@ -423,10 +419,6 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
       execute(Drupal.drush_status, repo, branch, build, buildtype, site, None, alias, revert=True, sites_deployed=sites_deployed) # This will revert the database if it fails (maybe hook_updates broke ability to bootstrap)
 
       if import_config:
-        if import_config_method == "cimy":
-          cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
-          if not cmi_tools:
-            import_config_method = "cim"
         execute(Drupal.config_import, repo, branch, build, buildtype, site, alias, drupal_version, import_config_method, cimy_mapping, previous_build, sites_deployed=sites_deployed) # This will revert database and settings if it fails.
 
       # Let's allow developers to use other config management for imports, such as CMI
@@ -440,10 +432,6 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
       execute(Drupal.drush_status, repo, branch, build, buildtype, site, None, alias, revert=True, sites_deployed=sites_deployed) # This will revert the database if it fails (maybe hook_updates broke ability to bootstrap)
 
       if import_config:
-        if import_config_method == "cimy":
-          cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
-          if not cmi_tools:
-            import_config_method = "cim"
         execute(Drupal.config_import, repo, branch, build, buildtype, site, alias, drupal_version, import_config_method, cimy_mapping, previous_build, sites_deployed=sites_deployed) # This will revert database and settings if it fails.
 
       # Let's allow developers to use other config management for imports, such as CMI

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -193,9 +193,6 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
           path = site_root + "/www"
       execute(common.PHP.composer_command, path, "install", None, no_dev, composer_lock)
 
-  if drupal_version > 7 and import_config_method == "cimy":
-    cimy_mapping = {}
-    cimy_mapping = DrupalConfig.configure_cimy_params(config, buildtype)
 
   # Compile a site mapping, which is needed if this is a multisite build
   # Just sets to 'default' if it is not
@@ -247,6 +244,10 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
     print "featurebranch_vhost: %s" % FeatureBranches.featurebranch_vhost
 
     site_exists = DrupalUtils.check_site_exists(previous_build, site)
+
+    cimy_mapping = {}
+    if drupal_version > 7 and import_config_method == "cimy":
+      cimy_mapping = DrupalConfig.configure_cimy_params(config, site)
 
     if freshdatabase == "Yes" and buildtype == "custombranch":
       # For now custombranch builds to clusters cannot work

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -15,12 +15,14 @@ import AdjustConfiguration
 import Drupal
 import DrupalTests
 import DrupalUtils
+import DrupalConfig
 import FeatureBranches
 import InitialBuild
 import Revert
 # Needed to get variables set in modules back into the main script
 from DrupalTests import *
 from FeatureBranches import *
+from DrupalConfig import *
 
 # Override the shell env variable in Fabric, so that we don't see
 # pesky 'stdin is not a tty' messages when using sudo
@@ -95,6 +97,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   do_updates = common.ConfigFile.return_config_item(config, "Drupal", "do_updates", "boolean", True)
   run_cron = common.ConfigFile.return_config_item(config, "Drupal", "run_cron", "boolean", False)
   import_config = common.ConfigFile.return_config_item(config, "Drupal", "import_config", "boolean", import_config)
+  import_config_method = common.ConfigFile.return_config_item(config, "Drupal", "import_config_method", "string", "cim")
   ### @TODO: deprecated, can be removed later
   fra = common.ConfigFile.return_config_item(config, "Features", "fra", "boolean", False, True, True, replacement_section="Drupal")
   # This is the correct location for 'fra' - note, respect the deprecated value as default
@@ -179,6 +182,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   # We need to cast version as an integer and use < 8
   if drupal_version < 8:
     import_config = False
+    import_config_method = "cim"
   if drupal_version > 7 and composer is True:
     # Sometimes people use the Drupal Composer project which puts Drupal 8's composer.json file in repo root.
     with shell_env(PHPRC='%s' % php_ini_file):
@@ -188,6 +192,10 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
         else:
           path = site_root + "/www"
       execute(common.PHP.composer_command, path, "install", None, no_dev, composer_lock)
+
+  if drupal_version > 7 and import_config_method == "cimy":
+    cimy_mapping = {}
+    cimy_mapping = DrupalConfig.configure_cimy_params(config, buildtype)
 
   # Compile a site mapping, which is needed if this is a multisite build
   # Just sets to 'default' if it is not
@@ -256,11 +264,11 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
       # Because this runs in Jenkins home directory, it will use 'system' drush
       if not site_exists:
         print "===> Didn't find a previous build so we'll install this new site %s" % url
-        initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profile, buildtype, sanitise, config, db_name, db_username, db_password, mysql_version, mysql_config, dump_file, sanitised_password, sanitised_email, cluster, rds, drupal_version, import_config, webserverport, behat_config, autoscale, php_ini_file, build_hook_version, previous_build)
+        initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profile, buildtype, sanitise, config, db_name, db_username, db_password, mysql_version, mysql_config, dump_file, sanitised_password, sanitised_email, cluster, rds, drupal_version, import_config, import_config_method, cimy_mapping, webserverport, behat_config, autoscale, php_ini_file, build_hook_version, previous_build)
       else:
         # Otherwise it's an existing build
         sites_deployed[alias] = site
-        existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, build, buildtype, previous_build, alias, site, no_dev, config, config_export, drupal_version, readonlymode, notifications_email, autoscale, do_updates, import_config, fra, run_cron, feature_branches, php_ini_file, build_hook_version, sites_deployed)
+        existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, build, buildtype, previous_build, alias, site, no_dev, config, config_export, drupal_version, readonlymode, notifications_email, autoscale, do_updates, import_config, import_config_method, cimy_mapping, fra, run_cron, feature_branches, php_ini_file, build_hook_version, sites_deployed)
 
     # Now everything should be in a good state, let's enable environment indicator for this site, if present
     execute(Drupal.environment_indicator, www_root, repo, branch, build, buildtype, alias, site, drupal_version)
@@ -297,7 +305,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
     behat_url = site_urls[test_alias]
 
     # After any build we want to run all the available automated tests
-    test_runner(www_root, repo, branch, build, test_alias, buildtype, behat_url, ssl_enabled, config, behat_config, behat_config_file, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, test_site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed)
+    test_runner(www_root, repo, branch, build, test_alias, buildtype, behat_url, ssl_enabled, config, behat_config, behat_config_file, import_config, import_config_method, cimy_mapping, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, test_site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed)
 
     behat_url = None
 
@@ -335,7 +343,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
 
 # Wrapper function for carrying out a first build of a site
 @task
-def initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profile, buildtype, sanitise, config, db_name, db_username, db_password, mysql_version, mysql_config, dump_file, sanitised_password, sanitised_email, cluster, rds, drupal_version, import_config, webserverport, behat_config, autoscale, php_ini_file, build_hook_version, previous_build):
+def initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profile, buildtype, sanitise, config, db_name, db_username, db_password, mysql_version, mysql_config, dump_file, sanitised_password, sanitised_email, cluster, rds, drupal_version, import_config, import_config_method, cimy_mapping, webserverport, behat_config, autoscale, php_ini_file, build_hook_version, previous_build):
   print "===> URL is http://%s" % url
 
   print "===> Looks like the site %s doesn't exist. We'll try and install it..." % url
@@ -368,12 +376,16 @@ def initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profi
     # any manual clean-up first. Everything else will have run, such as generate drush alias and
     # webserver vhost, so the issue can be fixed and the job re-run.
     if buildtype == "custombranch":
-      FeatureBranches.initial_db_and_config(repo, branch, build, site, import_config, drupal_version)
+      FeatureBranches.initial_db_and_config(repo, branch, build, site, import_config, import_config_method, cimy_mapping, drupal_version)
     else:
       execute(InitialBuild.initial_build_updatedb, repo, branch, build, site, drupal_version)
       execute(Drupal.drush_clear_cache, repo, branch, build, site, drupal_version)
       if import_config:
-        execute(InitialBuild.initial_build_config_import, repo, branch, build, site, drupal_version)
+        if import_config_method == "cimy":
+          cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
+          if not cmi_tools:
+            import_config_method = "cim"
+        execute(InitialBuild.initial_build_config_import, repo, branch, build, site, drupal_version, import_config_method, cimy_mapping)
         execute(Drupal.drush_clear_cache, repo, branch, build, site, drupal_version)
 
     # Let's allow developers to perform some post-build actions if they need to
@@ -383,7 +395,7 @@ def initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profi
 
 # Wrapper function for building an existing site
 @task
-def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, build, buildtype, previous_build, alias, site, no_dev, config, config_export, drupal_version, readonlymode, notifications_email, autoscale, do_updates, import_config, fra, run_cron, feature_branches, php_ini_file, build_hook_version, sites_deployed):
+def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, build, buildtype, previous_build, alias, site, no_dev, config, config_export, drupal_version, readonlymode, notifications_email, autoscale, do_updates, import_config, import_config_method, cimy_mapping, fra, run_cron, feature_branches, php_ini_file, build_hook_version, sites_deployed):
   print "===> Looks like the site %s exists already. We'll try and launch a new build..." % url
   with shell_env(PHPRC='%s' % php_ini_file):
     execute(AdjustConfiguration.adjust_settings_php, repo, branch, build, buildtype, alias, site)
@@ -410,7 +422,11 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
       execute(Drupal.drush_status, repo, branch, build, buildtype, site, None, alias, revert=True, sites_deployed=sites_deployed) # This will revert the database if it fails (maybe hook_updates broke ability to bootstrap)
 
       if import_config:
-        execute(Drupal.config_import, repo, branch, build, buildtype, site, alias, drupal_version, previous_build, sites_deployed=sites_deployed) # This will revert database and settings if it fails.
+        if import_config_method == "cimy":
+          cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
+          if not cmi_tools:
+            import_config_method = "cim"
+        execute(Drupal.config_import, repo, branch, build, buildtype, site, alias, drupal_version, import_config_method, cimy_mapping, previous_build, sites_deployed=sites_deployed) # This will revert database and settings if it fails.
 
       # Let's allow developers to use other config management for imports, such as CMI
       execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='config', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_primary'])
@@ -423,7 +439,11 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
       execute(Drupal.drush_status, repo, branch, build, buildtype, site, None, alias, revert=True, sites_deployed=sites_deployed) # This will revert the database if it fails (maybe hook_updates broke ability to bootstrap)
 
       if import_config:
-        execute(Drupal.config_import, repo, branch, build, buildtype, site, alias, drupal_version, previous_build, sites_deployed=sites_deployed) # This will revert database and settings if it fails.
+        if import_config_method == "cimy":
+          cmi_tools = DrupalConfig.check_cmi_tools_exists(repo, branch, build, site)
+          if not cmi_tools:
+            import_config_method = "cim"
+        execute(Drupal.config_import, repo, branch, build, buildtype, site, alias, drupal_version, import_config_method, cimy_mapping, previous_build, sites_deployed=sites_deployed) # This will revert database and settings if it fails.
 
       # Let's allow developers to use other config management for imports, such as CMI
       execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='config', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_primary'])
@@ -441,14 +461,14 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
 
 # Wrapper function for runnning automated tests on a site
 @task
-def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, config, behat_config, behat_config_file, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed):
+def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, config, behat_config, behat_config_file, import_config, import_config_method, cimy_mapping, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed):
   # Run simpletest tests
   execute(DrupalTests.run_tests, repo, branch, build, config, drupal_version, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, www_root)
 
   # Run behat tests
   if behat_config:
     if buildtype in behat_config['behat_buildtypes']:
-      behat_tests_failed = DrupalTests.run_behat_tests(repo, branch, build, alias, site, buildtype, url, ssl_enabled, behat_config_file, behat_config['behat_junit'], drupal_version, behat_config['behat_tags'], behat_config['behat_modules'])
+      behat_tests_failed = DrupalTests.run_behat_tests(repo, branch, build, alias, site, buildtype, url, ssl_enabled, behat_config_file, behat_config['behat_junit'], import_config, import_config_method, cimy_mapping, drupal_version, behat_config['behat_tags'], behat_config['behat_modules'])
   else:
     print "===> No behat tests."
 


### PR DESCRIPTION
Fixes #162 by providing the ability to use CMI Tools for config management by setting a value in config.ini.

It needs to be included in composer.json or directly committed (whichever method is used in the project) and the following added to the correct config.ini file, under the [Drupal] section:

```
import_config_method=cimy
default_cimy_source=../config/sync/default
site1_cimy_source=../config/sync/site1
```

The above example is for a multisite setup where the sites in `sites/default` and `sites/site1` are being built. Those are the **required** options. There are also optional options:

```
default_cimy_delete=../drush/config-delete-default.yml
default_cimy_install=../config_install_default/
```

The default values for those two options are `../drush/config-delete.yml` and `../config_install/`. The file at defined in the `default_cimy_delete` option, be it the default path or one set in config.ini, must exist in the repo, otherwise `drush cimy` will fail (the developers using CMI Tools will most likely know this).

---

If CMI Tools isn't installed but `import_config_method` is set to **cimy** in config.ini, the config import method will revert to **cim**. To change back to **cim**, either set `import_config_method=cim` in config.ini or remove that option entirely; the default is **cim**.

Cheers.