### PR TITLE
Fix order of repo cloning to allow pre-build hooks to run

### DIFF
--- a/flat/fabfile.py
+++ b/flat/fabfile.py
@@ -52,10 +52,11 @@ def main(repo, repourl, branch, build, buildtype, symassets="nosym", keepbuilds=
   if php_ini_file and not malicious_code:
     run("export PHPRC='%s'" % php_ini_file)
 
+  common.Utils.clone_repo(repo, repourl, branch, build, None, ssh_key)
+  
   # Let's allow developers to perform some pre-build actions if they need to
   execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='pre', hosts=env.roledefs['app_all'])
 
-  common.Utils.clone_repo(repo, repourl, branch, build, None, ssh_key)
   common.Utils.adjust_live_symlink(repo, branch, build)
   if symassets == "sym":
     Flat.symlink_assets(repo, branch, build)


### PR DESCRIPTION
The pre-build hooks are currently called before the repo is cloned on the target, thus failing.