### PR TITLE
config.ini override for FB teardowns

### DIFF
--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -139,16 +139,20 @@ def configure_feature_branch(buildtype, config, branch, alias):
 
 # Used to configure the mapping of sites to teardown, in case of a multisite setup
 @task
-def configure_teardown_mapping(repo, branch, buildtype, config_filename, mapping):
+def configure_teardown_mapping(repo, branch, buildtype, config_filename, config_fullpath, mapping):
   with settings(warn_only=True):
-    buildtype_config_filename = buildtype + '.' + config_filename
-    if run("stat /var/www/live.%s.%s/%s" % (repo, branch, buildtype_config_filename)).succeeded:
-      config_filename = buildtype_config_filename
-    else:
-      if run("stat /var/www/live.%s.%s/%s" % (repo, branch, config_filename)).failed:
-        raise SystemExit("Could not find any kind of config.ini file on the server the site is been torn down from. Failing the teardown build.")
 
-    config_filepath = "/var/www/live.%s.%s/%s" % (repo, branch, config_filename)
+    if config_fullpath:
+      config_filepath = config_filename
+    else:
+      buildtype_config_filename = buildtype + '.' + config_filename
+      if run("stat /var/www/live.%s.%s/%s" % (repo, branch, buildtype_config_filename)).succeeded:
+        config_filename = buildtype_config_filename
+      else:
+        if run("stat /var/www/live.%s.%s/%s" % (repo, branch, config_filename)).failed:
+          raise SystemExit("Could not find any kind of config.ini file on the server the site is been torn down from. Failing the teardown build.")
+
+      config_filepath = "/var/www/live.%s.%s/%s" % (repo, branch, config_filename)
 
     if run("grep \"\[Sites\]\" %s" % config_filepath).return_code != 0:
       print "###### Didn't find a [Sites] section in %s, so assume this is NOT a multisite build. In which case, we just need to teardown the default site."

--- a/drupal/fabfile-teardown.py
+++ b/drupal/fabfile-teardown.py
@@ -17,9 +17,14 @@ env.shell = '/bin/bash -c'
 
 
 @task
-def main(repo, branch, buildtype, alias=None, url=None, restartvarnish="yes", restartwebserver="yes", mysql_config='/etc/mysql/debian.cnf', config_filename="config.ini"):
+def main(repo, branch, buildtype, alias=None, url=None, restartvarnish="yes", restartwebserver="yes", mysql_config='/etc/mysql/debian.cnf', config_filename="config.ini", config_fullpath=False):
   if alias is None:
     alias = repo
+
+  if config_fullpath == "False":
+    config_fullpath = False
+  if config_fullpath == "True":
+    config_fullpath = True
 
   global varnish_restart
   global nginx_restart
@@ -54,7 +59,7 @@ def main(repo, branch, buildtype, alias=None, url=None, restartvarnish="yes", re
     raise SystemError("The %s site does not exist on the server, so there is nothing to tear down. Aborting." % branch)
 
   mapping = {}
-  mapping = FeatureBranches.configure_teardown_mapping(repo, branch, buildtype, config_filename, mapping)
+  mapping = FeatureBranches.configure_teardown_mapping(repo, branch, buildtype, config_filename, config_fullpath, mapping)
 
   for alias,site in mapping.iteritems():
 


### PR DESCRIPTION
We provide the ability to set a fullpath (path override, effectively) for the config.ini file when deploying a site (or feature branch site), but we don't have this ability when tearing the build down. If a feature branch is built using a config.ini override path, it can't be torn down with Jenkins because Jenkins will use the wrong config.ini file.