### PR TITLE
Primary server build hooks and other small changes

### DIFF
--- a/common/PHP.py
+++ b/common/PHP.py
@@ -56,4 +56,4 @@ def composer_command(site_root, composer_command="install", package_to_install=N
 
   with cd(site_root):
     print "===> Running the composer command `%s` in the directory %s" % (this_command, site_root)
-    run(this_command)
+    common.Utils._sshagent_run(this_command)

--- a/common/PHP.py
+++ b/common/PHP.py
@@ -56,4 +56,4 @@ def composer_command(site_root, composer_command="install", package_to_install=N
 
   with cd(site_root):
     print "===> Running the composer command `%s` in the directory %s" % (this_command, site_root)
-    common.Utils._sshagent_run(this_command)
+    run(this_command)

--- a/common/Utils.py
+++ b/common/Utils.py
@@ -354,6 +354,7 @@ def perform_client_deploy_hook(repo, build_path, build, buildtype, config, stage
   print "===> Looking for custom developer hooks at the %s stage for %s builds" % (stage, buildtype)
 
   malicious_commands = ['env.host_string', 'env.host', 'rm -rf /', 'ssh']
+  pre_stages = ['pre', 'pre-prim']
 
   if config.has_section("%s-%s-build" % (buildtype, stage)):
     print "===> Found %s-%s-build hooks, executing" % (buildtype, stage)
@@ -372,7 +373,7 @@ def perform_client_deploy_hook(repo, build_path, build, buildtype, config, stage
             print "===> Executing shell script %s" % option
 
             run("chmod +x /var/www/%s_%s_%s/build-hooks/%s" %(repo, build_path, build, option))
-            if stage != 'pre':
+            if stage not in pre_stages:
               with settings(warn_only=True):
                 if run("/var/www/%s_%s_%s/build-hooks/%s" %(repo, build_path, build, option)).failed:
                   print "Could not run build hook. Uh oh."
@@ -393,7 +394,7 @@ def perform_client_deploy_hook(repo, build_path, build, buildtype, config, stage
             else:
               fab_command = "fab -H %s -f %s main:repo=%s,branch=%s,build=%s,alias=%s,site=%s" % (env.host, hook_file, repo, build_path, build, alias, site)
 
-            if stage != 'pre':
+            if stage not in pre_stages:
               with settings(warn_only=True):
                 if local("%s" % fab_command).failed:
                   print "Could not run build hook. Uh oh."

--- a/drupal/fabfile-editorial.py
+++ b/drupal/fabfile-editorial.py
@@ -101,3 +101,4 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, config_filename
   # Final clean up and run tests, if applicable
   execute(common.Services.clear_php_cache, hosts=env.roledefs['app_all'])
   execute(common.Services.clear_varnish_cache, hosts=env.roledefs['app_all'])
+  execute(common.Utils.remove_old_builds, repo, branch, keepbuilds, hosts=env.roledefs['app_all'])

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -177,6 +177,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
 
   # Let's allow developers to perform some early actions if they need to
   execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='pre', build_hook_version="1", hosts=env.roledefs['app_all'])
+  execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='pre-prim', build_hook_version="1", hosts=env.roledefs['app_primary'])
 
   # @TODO: This will be a bug when Drupal 9 comes out!
   # We need to cast version as an integer and use < 8
@@ -387,6 +388,7 @@ def initial_build_wrapper(url, www_root, repo, branch, build, site, alias, profi
 
     # Let's allow developers to perform some post-build actions if they need to
     execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='post', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_all'])
+    execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='post-prim', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_primary'])
     execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='post-initial', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_all'])
 
 
@@ -401,6 +403,7 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
 
     # Let's allow developers to perform some actions right after Drupal is built
     execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='mid', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_all'])
+    execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='mid-prim', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_primary'])
 
     # Export the config if we need to (Drupal 8+)
     if config_export:
@@ -446,6 +449,7 @@ def existing_build_wrapper(url, www_root, site_root, site_link, repo, branch, bu
 
     # Let's allow developers to perform some post-build actions if they need to
     execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='post', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_all'])
+    execute(common.Utils.perform_client_deploy_hook, repo, branch, build, buildtype, config, stage='post-prim', build_hook_version=build_hook_version, alias=alias, site=site, hosts=env.roledefs['app_primary'])
 
 
 # Wrapper function for runnning automated tests on a site

--- a/symfony/fabfile.py
+++ b/symfony/fabfile.py
@@ -94,6 +94,8 @@ def main(repo, repourl, branch, build, buildtype, siteroot, keepbuilds=10, url=N
   if php_ini_file and not malicious_code:
     run("export PHPRC='%s'" % php_ini_file)
 
+  execute(common.Utils.clone_repo, repo, repourl, branch, build, buildtype, ssh_key, hosts=env.roledefs['app_all'])
+
   # Let's allow developers to perform some early actions if they need to
   execute(common.Utils.perform_client_deploy_hook, repo, buildtype, build, buildtype, config, stage='pre', hosts=env.roledefs['app_all'])
 
@@ -107,7 +109,6 @@ def main(repo, repourl, branch, build, buildtype, siteroot, keepbuilds=10, url=N
       if keepbackup:
         execute(Symfony.backup_db, repo, console_buildtype, build)
 
-  execute(common.Utils.clone_repo, repo, repourl, branch, build, buildtype, ssh_key, hosts=env.roledefs['app_all'])
   symfony_version = Symfony.determine_symfony_version(repo, buildtype, build)
   print "===> Checking symfony_version: %s" % symfony_version
   execute(Symfony.update_resources, repo, buildtype, build)


### PR DESCRIPTION
Did some basic tests with the pre-prim step and it appears to work fine.

Editorial builds needed to remove old builds, so they now do upon successful completion of a deployment.

The pre-hook step was being called **before** the Symfony repo was cloned down, so the pre hooks never fired because Jenkins could not find them. I've moved the clone_repo call so it runs before pre hooks are run.