### PR TITLE
Various changes

### DIFF
--- a/drupal/AdjustConfiguration.py
+++ b/drupal/AdjustConfiguration.py
@@ -4,6 +4,7 @@ import Revert
 
 
 # Adjust settings.php. Copy the relevant file based on the branch, delete the rest.
+# Failures here should be reverting the build entirely. If it fails to find settings.inc, or symlink in the file, the build will fail and the site being deployed and all sites that have been deployed will remain offline. All sites that have been deployed should have their databases reverted, as they could have had database updates applied.
 @task
 @roles('app_all')
 def adjust_settings_php(repo, branch, build, buildtype, alias, site):

--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -289,6 +289,7 @@ def prepare_database(repo, branch, build, buildtype, alias, site, syncbranch, or
 
 
 # Run a drush status against that build
+# Failures here should be reverting the database, because the site gets taken offline. If it fails to run drush st and the build fails, the site will remain offline! Probably need to revert the db nearly every time this function fails, as it is called after the site is taken offline. Only caveat *might* be when Drupal.prepare_database() is called during a feature branch build.
 @task
 @roles('app_primary')
 def drush_status(repo, branch, build, buildtype, site, drush_runtime_location=None, alias=None, revert=False, revert_settings=False, sites_deployed=None):
@@ -301,6 +302,7 @@ def drush_status(repo, branch, build, buildtype, site, drush_runtime_location=No
     if revert == False and revert_settings == True:
       for revert_alias,revert_site in sites_deployed.iteritems():
         execute(Revert._revert_settings, repo, branch, build, buildtype, revert_site, revert_alias)
+        execute(Revert._revert_go_online, repo, branch, build, site)
     else:
       if revert:
         for revert_alias,revert_site in sites_deployed.iteritems():

--- a/drupal/Revert.py
+++ b/drupal/Revert.py
@@ -16,7 +16,17 @@ def _revert_db(repo, branch, build, buildtype, site):
   drush_runtime_location = "/var/www/live.%s.%s/www/sites/%s" % (repo, branch, site)
   drush_output = Drupal.drush_status(repo, branch, build, buildtype, site, drush_runtime_location)
   db_name = Drupal.get_db_name(repo, branch, build, buildtype, site, drush_output)
+
+  # Get Drupal version to pass to cache clear and _revert_go_online()
+  drupal_version = run("echo \"%s\" | grep \"drupal-version\" | cut -d\: -f2 | cut -d. -f1" % drush_output)
+  drupal_version = drupal_version.strip()
+  # Older versions of Drupal put version in single quotes
+  drupal_version = drupal_version.strip("'")
+
   common.MySQL.mysql_revert_db(db_name, build)
+  Drupal.drush_clear_cache(repo, branch, build, site, drupal_version)
+  _revert_go_online(repo, branch, build, site, drupal_version)
+
 
 # Function to revert settings.php change for when a build fails and database is reverted
 @task
@@ -30,3 +40,30 @@ def _revert_settings(repo, branch, build, buildtype, site, alias):
       print "===> Could not revert settings.php. Manual intervention required."
     else:
       print "===> Reverted settings.php"
+
+
+# Function to put the site back online after a revert, as the site would have been put into maintenance mode *before* the backup was taken
+@task
+@roles('app_primary')
+def _revert_go_online(repo, branch, build, site, drupal_version=None):
+  print "===> Bringing the %s site back online." % site
+
+  drush_runtime_location = "/var/www/live.%s.%s/www/sites/%s" % (repo, branch, site)
+
+  with settings(warn_only=True):
+    if drupal_version is None:
+      drush_output = Drupal.drush_status(repo, branch, build, buildtype, site, drush_runtime_location)
+
+      # Get Drupal version to pass to cache clear and _revert_go_online()
+      drupal_version = run("echo \"%s\" | grep \"drupal-version\" | cut -d\: -f2 | cut -d. -f1" % drush_output)
+      drupal_version = drupal_version.strip()
+      # Older versions of Drupal put version in single quotes
+      drupal_version = drupal_version.strip("'")
+
+    if drupal_version > 7:
+      online_command = "state-set system.maintenancemode 0"
+    else:
+      online_command = "vset site_offline 0"
+
+    DrupalUtils.drush_command(online_command, site, drush_runtime_location)
+    Drupal.drush_clear_cache(repo, branch, build, site, drupal_version)


### PR DESCRIPTION
Various changes included in this:

1. Repositioning the database backup call so it happens **after** the site is taken offline. As a result, I've had to add a function to Revert.py to bring the site back online after a revert happens.
2. Reintroduce the ability to pass in `do_updates` via the Jenkins job. I don't think this should be handled in config.ini (or prod.config.ini for production sites), as it would be far more convenient to do this at the time of running a prod build.
With this, however, a database backup will still be taken even though the site is not taken offline. Pretty edge case, though. Perhaps a discussion with our client in question needs to be had to encourage them to use readonly mode instead. But, this change, ideally, needs to go through before that conversation otherwise it'll hold up some of their other work. 
3. Introduced the ability to switch off setting a scrambled username and password for `user 1`. I realised that in some cases, user 1 can be tied into Drupal content and/or groups, etc, and in some cases, while we advise clients to not use the account, some might still want to (and it is their site, after all).

I don't know if we want, or need, the cache clear at https://github.com/codeenigma/deployments/pull/299/files#diff-c181856ec7676765a83b8cf37dcc5e5eR27?

I put it in for now, just to be sure. Cache will be cleared after the site is brought back online.