### PR TITLE
Remove DEFINER statements from database backup when reverting a build.

### DIFF
--- a/common/GenericSync.py
+++ b/common/GenericSync.py
@@ -1,0 +1,14 @@
+from fabric.api import *
+import string
+
+# Define a dictionary containing server roles
+@task
+def define_roles(source_server, target_server):
+  all_servers = [source_server, target_server]
+  env.roledefs = {
+    'source': source_server,
+    'target': target_server,
+    'all': all_servers,
+  }
+
+  env.host = env.roledefs['source']

--- a/common/MySQL.py
+++ b/common/MySQL.py
@@ -153,4 +153,4 @@ def mysql_revert_db(db_name, build, mysql_config='/etc/mysql/debian.cnf'):
   print "===> Waiting 5 seconds to let MySQL internals catch up"
   time.sleep(5)
   print "===> Restoring the database from backup"
-  sudo("if [ -f ~jenkins/dbbackups/%s_prior_to_%s.sql.gz ]; then zcat ~jenkins/dbbackups/%s_prior_to_%s.sql.gz | mysql --defaults-file=%s -D %s; fi" % (db_name, build, db_name, build, mysql_config, db_name))
+  sudo("if [ -f ~jenkins/dbbackups/%s_prior_to_%s.sql.gz ]; then zcat ~jenkins/dbbackups/%s_prior_to_%s.sql.gz | sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' | mysql --defaults-file=%s -D %s; fi" % (db_name, build, db_name, build, mysql_config, db_name))

--- a/common/fabfile-genericsync.py
+++ b/common/fabfile-genericsync.py
@@ -1,0 +1,14 @@
+from fabric.api import *
+import GenericSync
+
+@task
+def main(site_name, source_server, source_database, target_server, target_database, mysql_config='/etc/mysql/debian.cnf'):
+  user = "jenkins"
+
+  GenericSync.define_roles(source_server, target_server)
+
+  env.host_string = '%s'@'%s' % (user, env.host)
+
+  execute(GenericSync.fetch_source_db, site_name, source_database, mysql_config, hosts=env.roledefs['source'])
+  execute(GenericSync.import_db, site_name, target_database, mysql_config, hosts=env.roledefs['target'])
+  execute(GenericSync.clean_up, site_name, hosts=env.roledefs['all'])


### PR DESCRIPTION
Also accidentally committed the GenericSync stuff I was working on way back when, but I don't think that's an issue. Might as well keep in place.