### PR TITLE
Feature branch teardown when using remote DB

### DIFF
--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -173,7 +173,7 @@ def configure_teardown_mapping(repo, branch, buildtype, config_filename, config_
 
 # Used for Drupal build teardowns.
 @task
-def remove_site(repo, branch, alias, site, mysql_config):
+def remove_site(repo, branch, alias, site, mysql_config, mysql_user_ip):
   # Drop DB...
   # 'build' and 'buildtype' can be none because only needed for revert which isn't relevant
   # This needs to be in a with settings(warn_only=True) to prevent the build from failing if the site is broken
@@ -188,7 +188,7 @@ def remove_site(repo, branch, alias, site, mysql_config):
 
   print "===> Dropping database and user: %s" % dbname
   sudo("mysql --defaults-file=%s -e 'DROP DATABASE IF EXISTS `%s`;'" % (mysql_config, dbname))
-  sudo("mysql --defaults-file=%s -e \"DROP USER \'%s\'@\'localhost\';\"" % (mysql_config, dbname))
+  sudo("mysql --defaults-file=%s -e \"DROP USER \'%s\'@\'%s\';\"" % (mysql_config, dbname, mysql_user_ip))
 
   with settings(warn_only=True):
     # Remove files directories

--- a/drupal/fabfile-teardown.py
+++ b/drupal/fabfile-teardown.py
@@ -17,7 +17,7 @@ env.shell = '/bin/bash -c'
 
 
 @task
-def main(repo, branch, buildtype, alias=None, url=None, restartvarnish="yes", restartwebserver="yes", mysql_config='/etc/mysql/debian.cnf', config_filename="config.ini", config_fullpath=False):
+def main(repo, branch, buildtype, alias=None, url=None, restartvarnish="yes", restartwebserver="yes", mysql_config='/etc/mysql/debian.cnf', config_filename="config.ini", config_fullpath=False, mysql_user_ip='localhost'):
   if alias is None:
     alias = repo
 
@@ -69,7 +69,7 @@ def main(repo, branch, buildtype, alias=None, url=None, restartvarnish="yes", re
     # --------------
     # If this is the first build, attempt to install the site for the first time.
     try:
-      FeatureBranches.remove_site(repo, branch, alias, site, mysql_config)
+      FeatureBranches.remove_site(repo, branch, alias, site, mysql_config, mysql_user_ip)
       common.BuildTeardown.remove_vhost(repo, branch, webserver, alias)
       common.BuildTeardown.remove_http_auth(repo, branch, webserver, alias)
       FeatureBranches.remove_drush_alias(alias, branch)


### PR DESCRIPTION
Workaround for when feature branches use a remote database, which prevented them from being torn down.