### PR TITLE
Feature branch teardown fix

### DIFF
--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -117,6 +117,23 @@ def get_db_name(repo, branch, build, buildtype, site, drush_output):
   return db_name
 
 
+# Get the database username of an existing Drupal website
+@task
+@roles('app_primary')
+def get_db_user(repo, branch, site, drush_output):
+  db_user = None
+  db_user = run("echo \"%s\" | grep \"db-username:\" | cut -d \":\" -f 2" % drush_output)
+
+  # If the dbuser variable is empty for whatever reason, resort to grepping settings.php
+  if not db_user:
+    with cd("/var/www/live.%s.%s/www/sites/%s" % (repo, branch, site)):
+      print "===> drush did not give us a database username so grepping the settings file"
+      db_user = sudo("grep \"'username' => '%s*\" settings.php | cut -d \">\" -f 2" % repo)
+      db_user = db_user.translate(None, "',")
+  print "===> Database username determined to be %s" % db_user
+  return db_user
+
+
 # Generate a crontab for running drush cron on this site
 @task
 @roles('app_primary')

--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -181,14 +181,19 @@ def remove_site(repo, branch, alias, site, mysql_config, mysql_user_ip):
     drush_runtime_location = "/var/www/live.%s.%s/www/sites/%s" % (repo, branch, site)
     drush_output = Drupal.drush_status(repo, branch, None, None, site, drush_runtime_location)
     dbname = Drupal.get_db_name(repo, branch, None, None, site, drush_output)
+    dbuser = Drupal.get_db_user(repo, branch, site, drush_output)
 
   # If the dbname variable is still empty, fail the build early
   if not dbname:
     raise SystemExit("###### Could not determine the database name, so we cannot proceed with tearing down the site.")
 
-  print "===> Dropping database and user: %s" % dbname
+  # If the dbuser variable is still empty, fail the build early
+  if not dbuser:
+    raise SystemExit("###### Could not determine the database username, so we cannot proceed with tearing down the site.")
+
+  print "===> Dropping database %s and user %s" % (dbname, dbuser)
   sudo("mysql --defaults-file=%s -e 'DROP DATABASE IF EXISTS `%s`;'" % (mysql_config, dbname))
-  sudo("mysql --defaults-file=%s -e \"DROP USER \'%s\'@\'%s\';\"" % (mysql_config, dbname, mysql_user_ip))
+  sudo("mysql --defaults-file=%s -e \"DROP USER \'%s\'@\'%s\';\"" % (mysql_config, dbuser, mysql_user_ip))
 
   with settings(warn_only=True):
     # Remove files directories

--- a/drupal/FeatureBranches.py
+++ b/drupal/FeatureBranches.py
@@ -179,7 +179,7 @@ def remove_site(repo, branch, alias, site, mysql_config, mysql_user_ip):
   # This needs to be in a with settings(warn_only=True) to prevent the build from failing if the site is broken
   with settings(warn_only=True):
     drush_runtime_location = "/var/www/live.%s.%s/www/sites/%s" % (repo, branch, site)
-    drush_output = Drupal.drush_status(repo, branch, None, None, site, drush_runtime_location)
+    drush_output = run("cd %s && drush -l %s status --format=yaml" % (drush_runtime_location, site))
     dbname = Drupal.get_db_name(repo, branch, None, None, site, drush_output)
     dbuser = Drupal.get_db_user(repo, branch, site, drush_output)
 


### PR DESCRIPTION
Currently, if MySQL is set to anything but 5.5 in the config.ini file, feature branch teardowns have a chance of failing due to how we currently drop the database and database user.

At times, if the branch in use has a long name, the database username will differ from the database name, which causes issues when trying to remove the database user. This PR fixes that, along with a long-standing issue whereby a feature branch build can't be removed if the database can't be bootstrapped.