### PR TITLE
Append a / when searching for the root in a vhost during teardowns.

### DIFF
--- a/common/BuildTeardown.py
+++ b/common/BuildTeardown.py
@@ -9,7 +9,7 @@ def remove_vhost(repo, branch, webserver, alias):
   with settings(warn_only=True):
     print "===> Unlinking and removing %s vhost..." % webserver
     # We grep the config files for the correct symlink to be sure we delete the right one
-    conf_file = sudo("find /etc/%s/sites-enabled/ -name '*%s*' -print0 | xargs -r -0 grep -H 'live.%s.%s' | sort --version-sort | head -1 | awk '{print $1}' | cut -d '/' -f 5 | cut -d ':' -f 1" % (webserver, alias, repo, branch))
+    conf_file = sudo("find /etc/%s/sites-enabled/ -name '*%s*' -print0 | xargs -r -0 grep -H 'live.%s.%s/' | sort --version-sort | head -1 | awk '{print $1}' | cut -d '/' -f 5 | cut -d ':' -f 1" % (webserver, alias, repo, branch))
 
     print "%s conf file is: %s" % (webserver, conf_file)
 


### PR DESCRIPTION
This way, if two branches have very similar names, such as `fb_test` and `fb_testv2`, tearing down the former won't remove the latter's vhost, which is what was happening.