### PR TITLE
Post-online cache clears and phpunit

### DIFF
--- a/common/Tests.py
+++ b/common/Tests.py
@@ -11,7 +11,7 @@ import common.PHP
 # Run phpunit tests
 @task
 @roles('app_primary')
-def run_phpunit_tests(path_to_app, group='unit', path='www', phpunit_path='vendor/phpunit/phpunit/phpunit'):
+def run_phpunit_tests(path_to_app, group='unit', path='www', phpunit_path='vendor/phpunit/phpunit/phpunit', phpunit_install=True):
   phpunit_tests_failed=True
   # We cannot make phpunit work with PHP 5.x, too many problems
   # Detect PHP version
@@ -23,8 +23,12 @@ def run_phpunit_tests(path_to_app, group='unit', path='www', phpunit_path='vendo
   with cd("%s" % path_to_app):
     # Make sure phpunit is available to use
     # We don't want to fail if it's already there
-    with settings(warn_only=True):
-      common.PHP.composer_command(path_to_app, "require", "phpunit/phpunit")
+    if phpunit_install:
+      with settings(warn_only=True):
+        print "===> Installing phpunit..."
+        common.PHP.composer_command(path_to_app, "require", "phpunit/phpunit")
+    else:
+      print "##### phpunit already installed."
 
     # Now let's look for a phpunit.xml file to use
     phpunit_xml = False

--- a/drupal/Drupal.py
+++ b/drupal/Drupal.py
@@ -638,6 +638,10 @@ def go_online(repo, branch, build, buildtype, alias, site, previous_build, reado
         else:
           DrupalUtils.drush_command("vset maintenance_mode 0", site, drush_runtime_location)
 
+  print "Clear the cache after bringing the %s site back online." % site
+  with settings(warn_only=True):
+     drush_clear_cache(repo, branch, build, site, drupal_version)
+
 
 # Set the username and password of user 1 to something random if the buildtype is 'prod'
 @task

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -139,6 +139,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   phpunit_group = common.ConfigFile.return_config_item(config, "Testing", "phpunit_group", "string", "unit")
   phpunit_test_directory = common.ConfigFile.return_config_item(config, "Testing", "phpunit_test_directory", "string", "%s/modules/custom" % application_directory)
   phpunit_path = common.ConfigFile.return_config_item(config, "Testing", "phpunit_path", "string", "vendor/phpunit/phpunit/phpunit")
+  phpunit_install = common.ConfigFile.return_config_item(config, "Testing", "phpunit_path", "boolean", True)
   # CodeSniffer itself is in common/Tests, but standards used here are Drupal specific, see drupal/DrupalTests.py for the wrapper to apply them
   codesniffer = common.ConfigFile.return_config_item(config, "Testing", "codesniffer", "boolean")
   codesniffer_extensions = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_extensions", "string", "php,module,inc,install,test,profile,theme,info,txt,md")
@@ -334,7 +335,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
     behat_url = site_urls[test_alias]
 
     # After any build we want to run all the available automated tests
-    test_runner(www_root, repo, branch, build, test_alias, buildtype, behat_url, ssl_enabled, db_backup, config, behat_config, behat_config_file, import_config, import_config_method, cimy_mapping, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, test_site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed)
+    test_runner(www_root, repo, branch, build, test_alias, buildtype, behat_url, ssl_enabled, db_backup, config, behat_config, behat_config_file, import_config, import_config_method, cimy_mapping, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, phpunit_install, test_site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed)
 
     behat_url = None
 
@@ -500,7 +501,7 @@ def existing_build_wrapper(url, www_root, application_directory, site_root, site
 
 # Wrapper function for runnning automated tests on a site
 @task
-def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, db_backup, config, behat_config, behat_config_file, import_config, import_config_method, cimy_mapping, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed):
+def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enabled, db_backup, config, behat_config, behat_config_file, import_config, import_config_method, cimy_mapping, drupal_version, phpunit_run, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_fail_build, phpunit_install, site, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, string_to_check, check_protocol, curl_options, notifications_email, build_hook_version, sites_deployed):
   # Run simpletest tests
   execute(DrupalTests.run_tests, repo, branch, build, config, drupal_version, codesniffer, codesniffer_extensions, codesniffer_ignore, codesniffer_paths, www_root)
 
@@ -515,7 +516,7 @@ def test_runner(www_root, repo, branch, build, alias, buildtype, url, ssl_enable
   if phpunit_run:
     # @TODO: We really need to figure out how to use execute() and fish returned variables from the response
     path_to_app = "%s/%s_%s_%s" % (www_root, repo, branch, build)
-    phpunit_tests_failed = common.Tests.run_phpunit_tests(path_to_app, phpunit_group, phpunit_test_directory, phpunit_path)
+    phpunit_tests_failed = common.Tests.run_phpunit_tests(path_to_app, phpunit_group, phpunit_test_directory, phpunit_path, phpunit_install)
     if phpunit_fail_build and phpunit_tests_failed:
       for revert_alias,revert_site in sites_deployed.iteritems():
         if db_backup:

--- a/drupal/fabfile.py
+++ b/drupal/fabfile.py
@@ -139,7 +139,7 @@ def main(repo, repourl, build, branch, buildtype, keepbuilds=10, url=None, fresh
   phpunit_group = common.ConfigFile.return_config_item(config, "Testing", "phpunit_group", "string", "unit")
   phpunit_test_directory = common.ConfigFile.return_config_item(config, "Testing", "phpunit_test_directory", "string", "%s/modules/custom" % application_directory)
   phpunit_path = common.ConfigFile.return_config_item(config, "Testing", "phpunit_path", "string", "vendor/phpunit/phpunit/phpunit")
-  phpunit_install = common.ConfigFile.return_config_item(config, "Testing", "phpunit_path", "boolean", True)
+  phpunit_install = common.ConfigFile.return_config_item(config, "Testing", "phpunit_install", "boolean", True)
   # CodeSniffer itself is in common/Tests, but standards used here are Drupal specific, see drupal/DrupalTests.py for the wrapper to apply them
   codesniffer = common.ConfigFile.return_config_item(config, "Testing", "codesniffer", "boolean")
   codesniffer_extensions = common.ConfigFile.return_config_item(config, "Testing", "codesniffer_extensions", "string", "php,module,inc,install,test,profile,theme,info,txt,md")


### PR DESCRIPTION
Currently, if a project installs phpunit in their main composer.json file and they want to run phpunit tests, it causes an issue as the scripts try to install phpunit again. So I'm introducing an option which can be used to disable that.