### PR TITLE
Drupal syncs

### DIFF
--- a/drupal/Sync.py
+++ b/drupal/Sync.py
@@ -202,7 +202,7 @@ def sync_db(orig_host, shortname, staging_shortname, staging_branch, prod_branch
         import_command = "mysql --defaults-file=/etc/mysql/debian.cnf %s" % dest_db_name
       else:
         import_command = "drush -l %s sql-cli" % site
-      sudo("bzcat ~/dbbackups/drupal_%s_%s_from_prod.sql.bz2 | %s " % (shortname, now, import_command))
+      sudo("bzcat /home/jenkins/dbbackups/drupal_%s_%s_from_prod.sql.bz2 | %s " % (shortname, now, import_command))
       # Set all users to the supplied e-mail address/password for stage testing
       if sanitise == 'yes':
         if sanitised_password is None:

--- a/drupal/fabfile-sync.py
+++ b/drupal/fabfile-sync.py
@@ -22,7 +22,7 @@ global config
 config = common.ConfigFile.read_config_file('sync.ini', False)
 
 @task
-def main(shortname, staging_branch, prod_branch, synctype='both', fresh_database='no', sanitise='yes', sanitised_password=None, sanitised_email=None, staging_shortname=None, remote_files_dir=None, staging_files_dir=None, sync_dir=None, config_filename='config.ini'):
+def main(shortname, staging_branch, prod_branch, synctype='both', fresh_database='no', sanitise='yes', sanitised_password=None, sanitised_email=None, staging_shortname=None, remote_files_dir=None, staging_files_dir=None, sync_dir=None, config_filename='config.ini', db_import_method='drush'):
 
   # Set the variables we need.
   drupal_version = None
@@ -88,7 +88,7 @@ def main(shortname, staging_branch, prod_branch, synctype='both', fresh_database
       # Database syncing
       if synctype == 'db' or synctype == 'both':
         Sync.backup_db(staging_shortname, staging_branch, stage_drupal_root, site)
-        Sync.sync_db(orig_host, shortname, staging_shortname, staging_branch, prod_branch, fresh_database, sanitise, sanitised_password, sanitised_email, config, drupal_version, stage_drupal_root, app_dir, site)
+        Sync.sync_db(orig_host, shortname, staging_shortname, staging_branch, prod_branch, fresh_database, sanitise, sanitised_password, sanitised_email, config, drupal_version, stage_drupal_root, app_dir, site, db_import_method)
         # Allow developer to run a script mid-way through a sync
         common.Utils.perform_client_sync_hook(path_to_drupal, staging_branch, 'mid-db', config_filename)
         Sync.drush_updatedb(orig_host, staging_shortname, staging_branch, stage_drupal_root, site)


### PR DESCRIPTION
Some Drupal syncs take ages because we're forcing the use of `drush sql-cli`. This PR provides the ability to use `mysql` instead by setting a parameter in the Jenkins job.